### PR TITLE
Polish DinkCoin display formatting

### DIFF
--- a/cogs/dinkcoin.py
+++ b/cogs/dinkcoin.py
@@ -46,7 +46,7 @@ class DinkCoin(commands.Cog):
                 name = user.display_name if user else f"User {row['user_id']}"
                 rank = len(embed.fields) + 1
                 embed.add_field(
-                    name=f"#{rank} {name}",
+                    name=f"{name}",
                     value=f"{float(row['balance']):g} DINK",
                     inline=False,
                 )

--- a/cogs/first.py
+++ b/cogs/first.py
@@ -48,7 +48,7 @@ class First(commands.Cog):
                 db_ops.record_dink_mint(ctx.author.id, DINK_MINT_AMOUNT)
                 await asyncio.sleep(0.5)
                 Author = ctx.author.mention
-                msg = f"{Author} is first today! 🥳 +{DINK_MINT_AMOUNT:g} DINK"
+                msg = f"{Author} is first today! 🥳 +{DINK_MINT_AMOUNT:g} **DINK**"
                 await ctx.channel.send(msg)
 
     @commands.command()

--- a/tests/test_first_commands.py
+++ b/tests/test_first_commands.py
@@ -39,7 +39,7 @@ async def test_first_wrong_channel(report, mock_bot, mock_ctx):
 async def test_first_successful_claim(
     mock_datetime, _mock_sleep, report, mock_db_ops, mock_bot, mock_ctx,
 ):
-    expected = f"{mock_ctx.author.mention} is first today! 🥳 +1 DINK"
+    expected = f"{mock_ctx.author.mention} is first today! 🥳 +1 **DINK**"
     est = pytz.timezone("US/Eastern")
     today = est.localize(datetime(2024, 6, 11, 8, 0, 0))
 


### PR DESCRIPTION
## Summary
- Remove rank prefixes from DinkCoin ledger embed field names
- Bold DINK in the `_1st` success message
- Update mocked `_1st` test expectation

## Test plan
- [ ] GitHub Actions test workflow passes
- [ ] Verify `_ledger` shows holder names without `#1`, `#2`, etc.
- [ ] Verify `_1st` success message shows `+1 **DINK**`