### PR TITLE
Suppress pandas PyMySQL warning in fetch_df

### DIFF
--- a/utils/db.py
+++ b/utils/db.py
@@ -1,6 +1,7 @@
 import pymysql
 import os
 import pandas as pd
+import warnings
 from dotenv import load_dotenv
 from datetime import datetime
 from contextlib import contextmanager
@@ -68,7 +69,13 @@ class Database:
     def fetch_df(self, query: str, params: Optional[tuple] = None) -> pd.DataFrame:
         """Fetch query results as pandas DataFrame"""
         with self.connection() as conn:
-            return pd.read_sql_query(query, conn, params=params)
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="pandas only supports SQLAlchemy connectable",
+                    category=UserWarning,
+                )
+                return pd.read_sql_query(query, conn, params=params)
 
 class DataOperations:
     def __init__(self):


### PR DESCRIPTION
## Summary

- Suppress the expected pandas `UserWarning` when `fetch_df` passes a PyMySQL connection to `pd.read_sql_query`
- Keeps the existing PyMySQL database layer unchanged (no SQLAlchemy migration)

Closes #6

## Test plan

- [x] GitHub Actions `Tests` workflow passes on this PR
- [ ] Confirm `/score` and other read commands no longer log the warning in production console