### PR TITLE
Add Grok self-knowledge tools for member-facing bot Q&A

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ def get_todays_date(timezone='US/Eastern'):
 
 ChatGPT intelligently recognizes when to invoke this function and uses the information to generate a response.
 
+#### Self-Knowledge Tools
+
+The Grok integration (`_ask` / `_voice`) is self-aware: alongside xAI's server-side web/X search, every request exposes client-side tools that let Grok look up how the bot itself works instead of guessing:
+
+| Tool | What it returns |
+|------|-----------------|
+| `get_bot_documentation` | Curated member-facing docs (`docs/self_knowledge/`) on the bot overview, the `_1st` game, DinkCoin, AI features, and server stats |
+| `list_bot_commands` | The live command list, generated from the registered cogs at runtime |
+| `get_first_game_stats` | Live first-game leaderboard, most recent winner, and current streak |
+| `get_dink_ledger` | Live top DINK holders and total circulation |
+
+Ask the bot "how does juice work?" or "who has the most DINK?" and it pulls the answer from these tools. To extend its knowledge, add a markdown file to `docs/self_knowledge/` and register it in `utils/self_knowledge.py` (`TOPICS`).
+
 ### DALL·E 3
 
 The bot is also connected to the DALL·E 3 API. It can take any prompt as described using natural language and generate a detail 1024x1024 image!

--- a/chatgpt_functions.py
+++ b/chatgpt_functions.py
@@ -1,16 +1,25 @@
 """
 Grok Responses API client and Grok Imagine image generation.
 Uses xAI's stateful Responses API: sessions are stored on xAI servers (30 days).
-Includes native search (web_search, x_search).
+
+Tools available to Grok on every request:
+- Server-side (run on xAI): web_search, x_search.
+- Client-side (run here): self-knowledge tools from utils/self_knowledge.py,
+  so Grok can look up the bot's own docs, command list, and live game/ledger
+  data when users ask about the bot itself.
+
 Logging to DB for every interaction.
 """
+import json
 import logging
 import os
 
 from dotenv import load_dotenv
 from xai_sdk import Client
-from xai_sdk.chat import user, system, image
+from xai_sdk.chat import user, system, image, tool, tool_result
 from xai_sdk.tools import web_search, x_search
+
+from utils import self_knowledge
 
 load_dotenv()
 
@@ -19,16 +28,68 @@ logger = logging.getLogger(__name__)
 DEFAULT_GROK_MODEL = "grok-4.3"
 GROK_IMAGINE_FILENAME = "grok-imagine.jpg"  # xAI base64 responses are JPEG
 
+# Safety cap on client-side tool round-trips per user message
+MAX_TOOL_ROUNDS = 5
+
 
 class GrokClient:
-    """Client for xAI Grok Responses API. Stateful sessions stored on xAI servers."""
+    """Client for xAI Grok Responses API. Stateful sessions stored on xAI servers.
 
-    def __init__(self, api_key=None):
+    Pass a Discord bot instance to enable live self-knowledge tools (command
+    list, first-game stats, DINK ledger). Without it, documentation lookups
+    still work but live data tools degrade gracefully.
+    """
+
+    def __init__(self, api_key=None, bot=None):
         self._client = Client(
             api_key=api_key or os.getenv("XAI_API_KEY"),
             timeout=3600,
         )
         self.model = DEFAULT_GROK_MODEL
+        self._tool_handlers = self_knowledge.build_tool_handlers(bot)
+        self._client_tools = [
+            tool(
+                name=schema["name"],
+                description=schema["description"],
+                parameters=schema["parameters"],
+            )
+            for schema in self_knowledge.TOOL_SCHEMAS
+        ]
+
+    def _build_tools(self) -> list:
+        return [web_search(), x_search(), *self._client_tools]
+
+    def _execute_tool_call(self, tool_call) -> str:
+        """Run one client-side tool call and return its string result."""
+        name = tool_call.function.name
+        handler = self._tool_handlers.get(name)
+        if handler is None:
+            logger.warning("Grok requested unknown tool: %s", name)
+            return f"Error: tool '{name}' is not available."
+        try:
+            args = json.loads(tool_call.function.arguments or "{}")
+        except json.JSONDecodeError:
+            args = {}
+        try:
+            result = handler(args)
+            logger.info("Grok self-knowledge tool used: %s(%s)", name, args)
+            return result
+        except Exception:
+            logger.exception("Self-knowledge tool %s failed", name)
+            return f"Error: tool '{name}' failed to execute."
+
+    def _sample_with_tools(self, chat):
+        """Sample a response, executing client-side tool calls until Grok answers."""
+        response = chat.sample()
+        rounds = 0
+        while getattr(response, "tool_calls", None) and rounds < MAX_TOOL_ROUNDS:
+            chat.append(response)
+            for tool_call in response.tool_calls:
+                output = self._execute_tool_call(tool_call)
+                chat.append(tool_result(output, tool_call_id=tool_call.id))
+            response = chat.sample()
+            rounds += 1
+        return response
 
     def send_message(
         self,
@@ -46,12 +107,14 @@ class GrokClient:
         - If previous_response_id is set, the message is appended to that conversation.
         - When image_urls are provided, store_messages is False (per xAI docs) and
           the returned response_id should not be used to continue (next turn starts fresh).
+        - Client-side self-knowledge tool calls are executed transparently before
+          the final text is returned.
         - Logs the interaction when user_id and message_id are provided.
         """
         has_images = bool(image_urls)
         store = not has_images
 
-        tools_list = [web_search(), x_search()]
+        tools_list = self._build_tools()
         if previous_response_id and store:
             chat = self._client.chat.create(
                 model=self.model,
@@ -76,7 +139,7 @@ class GrokClient:
             else:
                 chat.append(user(prompt))
 
-        response = chat.sample()
+        response = self._sample_with_tools(chat)
         server_usage = getattr(response, "server_side_tool_usage", None)
         if server_usage:
             logger.info("Grok server-side tools used: %s", server_usage)

--- a/cogs/ai.py
+++ b/cogs/ai.py
@@ -16,13 +16,23 @@ class AI(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
-        self.grok = GrokClient()
+        self.grok = GrokClient(bot=bot)
         # Single shared session for all users (last Grok response_id, or None for new conversation)
         self.last_response_id = None
         self._session_turns = 0  # turns in current session; reset when starting fresh or hitting limit
         self.system_prompt = (
-            "You are a coherent and helpful assistant in a guild on Discord. You think from first principles and reason step by step when applicable. "
-            "You have access to real-time search; use it to confirm facts and fetch primary sources for current events. "
+            "You are Peter Dinklage, the resident bot of this Discord server (Dinkscord). "
+            "You are not just a chat assistant: you run the daily _1st game, the DinkCoin (DINK) economy, "
+            "image generation, and server stats. Commands use the '_' prefix. "
+            "You speak to server members as yourself — never as a separate AI product. "
+            "Never mention API providers, model names, databases, table names, code files, "
+            "environment variables, or other internal implementation details. "
+            "You think from first principles and reason step by step when applicable. "
+            "You have tools to look up your own documentation (get_bot_documentation), your live command list "
+            "(list_bot_commands), and live data (get_first_game_stats, get_dink_ledger). "
+            "Whenever someone asks about you, your commands, your capabilities, the first game, juice, streaks, "
+            "DINK, or how any of your features work, call those tools and answer from their output instead of guessing. "
+            "You also have real-time web and X search; use them to confirm facts and fetch primary sources for current events. "
             "In your final answer, write economically. A single sentence should often be enough. "
             "Every sentence or phrase should be essential, such that removing it would make the final response incomplete or substantially worse. "
             "Do not use markdown bold (**text**) for whole responses or multiple sentences—especially after web search. "

--- a/docs/self_knowledge/ai_features.md
+++ b/docs/self_knowledge/ai_features.md
@@ -1,0 +1,37 @@
+# Chat, Images & Voice
+
+These are your AI-powered features. When explaining them to members, focus on
+**what they can do** — not how you work under the hood.
+
+## Chat — `_ask <question>`
+
+- Ask you anything. You can look things up on the web when needed.
+- **One shared conversation for the whole server** — everyone contributes to the
+  same chat thread, not separate threads per person.
+- After a while the conversation resets on its own so it doesn't grow forever.
+  `_clear` starts fresh immediately if someone wants a clean slate.
+- **Images**: attach a picture to the `_ask` message and you can see and talk
+  about it. Starting a message with an image begins a new conversation (the
+  previous thread isn't continued).
+
+## Image generation — `_imagine <prompt>`
+
+- Describe what you want and the bot generates an image.
+- Attach an image to the command to use it as a starting point for edits.
+
+## Voice — `_voice <prompt>`
+
+- You answer the prompt in text, then read that answer aloud as an MP3 file in
+  the channel.
+
+## Session reset — `_clear`
+
+- Wipes the current shared chat memory so the next `_ask` or `_voice` starts over
+  with no context from earlier messages.
+
+## Tips for members
+
+- Be specific in prompts for better `_imagine` results.
+- If the bot seems stuck on an old topic, someone can run `_clear`.
+- `_ask` works best for questions; `_imagine` is for pictures; `_voice` is when
+  they want to hear a reply.

--- a/docs/self_knowledge/dinkcoin.md
+++ b/docs/self_knowledge/dinkcoin.md
@@ -1,0 +1,31 @@
+# DinkCoin (DINK)
+
+DinkCoin is the server's pretend currency — a fun way to track bragging rights
+and trade with friends. It is **not real money**, has no cash value, and is not
+on any blockchain or crypto wallet.
+
+## How to get DINK
+
+- Win the daily `_1st` game. Each win earns **1 DINK**.
+- That is the only way new DINK enters the server — nobody can print it except
+  by winning first.
+
+## How to use DINK
+
+- `_balance` — see how much DINK you have.
+- `_ledger` — see who holds the most DINK on the server (top 10 by default, up to 20).
+- `_pay @user <amount>` — send DINK to another member.
+
+## Rules for paying
+
+- Only **whole numbers** of DINK (no decimals).
+- You can't pay yourself or bots.
+- You can't send more than you have — the bot will tell you your balance if you try.
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `_balance` | Your DINK balance |
+| `_ledger [limit]` | Top holders + total DINK on the server |
+| `_pay @user <amount>` | Send DINK to someone |

--- a/docs/self_knowledge/first_game.md
+++ b/docs/self_knowledge/first_game.md
@@ -1,0 +1,36 @@
+# The "First" Game
+
+The most popular game on the server: be the first person to claim the day.
+
+## How to play
+
+- Type `_1st` in **#general**. It won't work in other channels — the bot will
+  tell you to go to #general.
+- Only **one person** wins each day. A new day starts at **midnight US/Eastern**.
+- If you win, the bot announces it and you earn **1 DINK** (see the `dinkcoin` topic).
+- If someone already claimed today, the bot says first has been taken — try again
+  tomorrow.
+
+## Stats and scores
+
+- **Score** — how many daily wins you have total. `_score` shows the top 5
+  players plus the most recent winner and their current streak.
+- **Streak** — how many days in a row the same person has won first. `_stats`
+  (optionally `@someone`) shows a player's total wins, juice, and their longest
+  ever streak.
+- **Juice 🧃** — a lateness score. Each win earns the number of **minutes past
+  midnight Eastern** when you claimed (e.g. 12:07am = 7 juice; 11:30pm = 1410).
+  If nobody claims for a full day, the next winner also picks up 1440 juice per
+  missed day. Higher juice means you won *late* — it rewards patience and stealth.
+  `_juice` shows the top 5 total juice and the single-day record.
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `_1st` | Claim first for today (#general only, once per day) |
+| `_score` | Top 5 wins + most recent winner and streak |
+| `_stats [@user]` | One player's wins, juice, and longest streak |
+| `_juice` | Top 5 juice + single-day high score |
+| `_graph` | Chart of cumulative firsts over time |
+| `_juicegraph` | Chart of daily juice over time |

--- a/docs/self_knowledge/overview.md
+++ b/docs/self_knowledge/overview.md
@@ -1,0 +1,27 @@
+# About Peter Dinklage
+
+You are **Peter Dinklage**, the resident bot of the Dinkscord Discord server.
+Members interact with you using commands that start with `_` (underscore). Commands
+are case-insensitive.
+
+## What you do for the server
+
+- **Daily "first" game** — members race to claim the first win of the day with
+  `_1st`. Wins, streaks, and juice scores are tracked, with leaderboards and
+  graphs. See the `first_game` topic for the full rules.
+- **DinkCoin (DINK)** — a fun server currency earned by winning `_1st` and sent
+  between members with `_pay`. See the `dinkcoin` topic.
+- **Chat & creativity** — `_ask` for questions and conversation (including images
+  you attach), `_imagine` for AI art, `_voice` for a spoken reply, and `_clear`
+  to start a fresh chat. See the `ai_features` topic.
+- **Server stats** — you keep track of activity on the server and post a monthly
+  report. Stats are also on the public dashboard at
+  https://peterdinklage.streamlit.app/. See the `server_stats` topic.
+- **Fun & utilities** — `_ping`, `_hello`, `_simonsays`, and `_donation` (a thank-you
+  list of patrons who help keep the bot running).
+
+## How to talk about yourself
+
+When members ask what you are or what you can do, describe your **features and
+commands** in plain language. You are part of the server — not a separate product
+they need to sign up for. The first game only works in **#general**.

--- a/docs/self_knowledge/server_stats.md
+++ b/docs/self_knowledge/server_stats.md
@@ -1,0 +1,25 @@
+# Server Stats & Activity
+
+You help the server keep track of what's going on. Members mostly see this through
+leaderboards, graphs, and the monthly report — not through raw data.
+
+## What gets tracked
+
+- **Messages** — activity in channels (used for monthly rankings and the dashboard).
+- **First game** — every daily `_1st` win, which powers `_score`, `_stats`, `_juice`,
+  and the graphs.
+- **DINK** — balances and transfers from `_pay` and `_1st` wins.
+- **AI usage** — `_ask`, `_imagine`, and related commands (for server records).
+
+## What members see
+
+- **Monthly report** — on the 1st of each month at 9am Eastern, you post a summary
+  in #general ranking the top messengers from the previous month.
+- **Dashboard** — https://peterdinklage.streamlit.app/ shows server trends like
+  message counts and first-game stats over time.
+
+## If someone asks "does the bot log everything?"
+
+- You track server activity to run the games, economy, stats, and dashboard.
+- You don't need to explain technical details — just that activity on the server
+  is recorded so features like leaderboards and the monthly report work.

--- a/tests/test_self_knowledge.py
+++ b/tests/test_self_knowledge.py
@@ -1,0 +1,141 @@
+"""Tests for the Grok self-knowledge tools and the client-side tool-call loop."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from tests.reporting import SECTION_UNIT
+from utils import self_knowledge
+
+
+def test_every_topic_has_a_doc(report):
+    for topic in self_knowledge.TOPICS:
+        content = self_knowledge.get_topic(topic)
+        report.record(f"doc '{topic}'", "markdown content", content[:60], section=SECTION_UNIT)
+        assert content.startswith("#"), f"doc for {topic} missing or malformed"
+
+
+def test_unknown_topic_lists_available(report):
+    result = self_knowledge.get_topic("nonsense")
+    report.record("unknown topic", "error listing topics", result, section=SECTION_UNIT)
+    assert "Unknown topic" in result
+    for topic in self_knowledge.TOPICS:
+        assert topic in result
+
+
+def test_tool_schemas_match_handlers(report):
+    schema_names = {schema["name"] for schema in self_knowledge.TOOL_SCHEMAS}
+    handler_names = set(self_knowledge.build_tool_handlers(bot=None))
+    report.record("tool names", sorted(schema_names), sorted(handler_names), section=SECTION_UNIT)
+    assert schema_names == handler_names
+
+
+def test_build_command_reference_lists_real_commands(report, mock_bot):
+    from cogs.utility import Utility
+
+    cog = Utility(mock_bot)
+    fake_bot = MagicMock()
+    fake_bot.cogs = {"Utility": cog}
+
+    reference = self_knowledge.build_command_reference(fake_bot)
+
+    report.record("command reference", "_ping, _hello, _simonsays", reference, section=SECTION_UNIT)
+    assert "_ping" in reference
+    assert "_hello" in reference
+    assert "_simonsays <arg>" in reference
+
+
+def test_get_first_game_stats(report, mock_db_ops, sample_first_df):
+    mock_db_ops.get_table_data.return_value = sample_first_df
+
+    data = json.loads(self_knowledge.get_first_game_stats(bot=None))
+
+    report.record("leaderboard", "111 has 3 wins", data["leaderboard_top10"][0], section=SECTION_UNIT)
+    report.record("recent winner", "User 111", data["most_recent_winner"], section=SECTION_UNIT)
+    assert data["leaderboard_top10"][0] == {"name": "User 111", "wins": 3}
+    assert data["most_recent_winner"] == "User 111"
+    assert data["total_days_played"] == 4
+    assert data["current_streak_days"] == 1
+
+
+def test_get_dink_ledger_stats(report, mock_db_ops):
+    mock_db_ops.get_dink_ledger.return_value = pd.DataFrame(
+        {"user_id": ["111", "222"], "balance": [12.0, 5.0]}
+    )
+    mock_db_ops.get_total_dink_circulation.return_value = 17.0
+
+    data = json.loads(self_knowledge.get_dink_ledger_stats(bot=None))
+
+    report.record("top holder", "User 111 with 12 DINK", data["top_holders"][0], section=SECTION_UNIT)
+    report.record("circulation", 17.0, data["total_circulation"], section=SECTION_UNIT)
+    assert data["top_holders"][0] == {"name": "User 111", "balance": 12.0}
+    assert data["total_circulation"] == 17.0
+
+
+def _make_tool_call(name: str, arguments: dict, call_id: str = "call-1"):
+    tool_call = MagicMock()
+    tool_call.id = call_id
+    tool_call.function.name = name
+    tool_call.function.arguments = json.dumps(arguments)
+    return tool_call
+
+
+def test_send_message_executes_self_knowledge_tools(report, mock_db_ops):
+    """Grok requests a doc lookup; the client executes it and returns the final text."""
+    from chatgpt_functions import GrokClient
+
+    with patch("chatgpt_functions.Client") as mock_client_cls:
+        grok = GrokClient(api_key="test-key", bot=None)
+        chat = MagicMock()
+        mock_client_cls.return_value.chat.create.return_value = chat
+
+        tool_response = MagicMock()
+        tool_response.tool_calls = [
+            _make_tool_call("get_bot_documentation", {"topic": "dinkcoin"})
+        ]
+        final_response = MagicMock()
+        final_response.tool_calls = []
+        final_response.id = "resp-final"
+        final_response.content = "DINK is minted by winning _1st."
+        chat.sample.side_effect = [tool_response, final_response]
+
+        next_id, text = grok.send_message("how does dinkcoin work?", system_prompt="sys")
+
+    tool_messages = [
+        call.args[0]
+        for call in chat.append.call_args_list
+        if getattr(call.args[0], "tool_call_id", None) == "call-1"
+    ]
+    doc_sent_to_grok = tool_messages[0].content[0].text
+
+    report.record("sample calls", 2, chat.sample.call_count, section=SECTION_UNIT)
+    report.record("tool result", "DinkCoin markdown doc", doc_sent_to_grok[:60], section=SECTION_UNIT)
+    report.record("final text", final_response.content, text, section=SECTION_UNIT)
+    report.record("next id", "resp-final", next_id, section=SECTION_UNIT)
+
+    assert chat.sample.call_count == 2
+    assert "DinkCoin" in doc_sent_to_grok
+    assert text == "DINK is minted by winning _1st."
+    assert next_id == "resp-final"
+
+
+def test_send_message_caps_tool_rounds(report, mock_db_ops):
+    """A model that keeps requesting tools is cut off after MAX_TOOL_ROUNDS."""
+    from chatgpt_functions import MAX_TOOL_ROUNDS, GrokClient
+
+    with patch("chatgpt_functions.Client") as mock_client_cls:
+        grok = GrokClient(api_key="test-key", bot=None)
+        chat = MagicMock()
+        mock_client_cls.return_value.chat.create.return_value = chat
+
+        looping_response = MagicMock()
+        looping_response.tool_calls = [_make_tool_call("list_bot_commands", {})]
+        looping_response.id = "resp-loop"
+        looping_response.content = "still thinking"
+        chat.sample.return_value = looping_response
+
+        grok.send_message("hi", system_prompt="sys")
+
+    report.record("sample calls", MAX_TOOL_ROUNDS + 1, chat.sample.call_count, section=SECTION_UNIT)
+    assert chat.sample.call_count == MAX_TOOL_ROUNDS + 1

--- a/utils/self_knowledge.py
+++ b/utils/self_knowledge.py
@@ -1,0 +1,169 @@
+"""
+Self-knowledge toolkit for the Grok integration.
+
+Gives Grok a set of client-side tools it can call to understand the bot it is
+part of: documentation lookups (docs/self_knowledge/*.md), the live command
+list, and live game/ledger data. Tool schemas are plain dicts so this module
+stays independent of the xAI SDK; chatgpt_functions.py converts them.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DOCS_DIR = Path(__file__).resolve().parent.parent / "docs" / "self_knowledge"
+
+# topic name -> one-line description surfaced in the tool schema
+TOPICS = {
+    "overview": "What the bot is and what it can do for server members",
+    "first_game": "Rules of the daily _1st game: claiming, score, streaks, and juice",
+    "dinkcoin": "How DINK works: earning it, spending it, and the leaderboard",
+    "ai_features": "How _ask, _imagine, _voice, and _clear work for members",
+    "server_stats": "Activity tracking, the monthly report, and the public dashboard",
+}
+
+
+def get_topic(topic: str) -> str:
+    """Return the markdown documentation for a topic."""
+    if topic not in TOPICS:
+        available = ", ".join(sorted(TOPICS))
+        return f"Unknown topic '{topic}'. Available topics: {available}"
+    path = DOCS_DIR / f"{topic}.md"
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        logger.exception("Failed to read self-knowledge doc %s", path)
+        return f"Documentation for '{topic}' is unavailable right now."
+
+
+def build_command_reference(bot) -> str:
+    """Build a live command reference from the bot's registered cogs."""
+    if bot is None:
+        return (
+            "Live command registry unavailable. Use get_bot_documentation "
+            "(topics: overview, first_game, dinkcoin, ai_features) for command lists."
+        )
+    lines = ["Commands (prefix '_', case-insensitive):"]
+    for cog_name, cog in bot.cogs.items():
+        cog_doc = (cog.__doc__ or "").strip().splitlines()
+        lines.append(f"\n{cog_name}: {cog_doc[0] if cog_doc else ''}".rstrip())
+        for cmd in cog.get_commands():
+            help_text = (cmd.help or cmd.brief or "").strip().splitlines()
+            summary = help_text[0] if help_text else ""
+            params = " ".join(
+                f"<{p}>" for p in cmd.clean_params
+            )
+            usage = f"_{cmd.name} {params}".strip()
+            lines.append(f"  {usage} — {summary}")
+    return "\n".join(lines)
+
+
+def _resolve_name(bot, user_id) -> str:
+    if bot is not None:
+        user = bot.get_user(int(user_id))
+        if user is not None:
+            return user.display_name
+    return f"User {user_id}"
+
+
+def get_first_game_stats(bot=None) -> str:
+    """Live first-game data: leaderboard, current streak, most recent winner."""
+    from utils.db import db_ops, streak_calc
+
+    df = db_ops.get_table_data("firstlist_id")
+    if df.empty:
+        return json.dumps({"message": "No firsts have been claimed yet."})
+
+    counts = df.user_id.value_counts()
+    leaderboard = [
+        {"name": _resolve_name(bot, uid), "wins": int(wins)}
+        for uid, wins in counts.head(10).items()
+    ]
+    latest_uid = df.user_id.iloc[-1]
+    return json.dumps({
+        "leaderboard_top10": leaderboard,
+        "total_days_played": int(len(df)),
+        "most_recent_winner": _resolve_name(bot, latest_uid),
+        "most_recent_win_utc": str(df.timesent.iloc[-1]),
+        "current_streak_days": int(streak_calc.calculate_streak(df)),
+    })
+
+
+def get_dink_ledger_stats(bot=None) -> str:
+    """Live DinkCoin data: top holders and total circulation."""
+    from utils.db import db_ops
+
+    df = db_ops.get_dink_ledger(10)
+    holders = [
+        {"name": _resolve_name(bot, row["user_id"]), "balance": float(row["balance"])}
+        for _, row in df.iterrows()
+    ]
+    return json.dumps({
+        "top_holders": holders,
+        "total_circulation": db_ops.get_total_dink_circulation(),
+    })
+
+
+# Plain-dict tool schemas (converted to xAI SDK tools in chatgpt_functions.py)
+TOOL_SCHEMAS = [
+    {
+        "name": "get_bot_documentation",
+        "description": (
+            "Look up member-facing documentation about the bot. Use when someone "
+            "asks what you can do, how commands work, the _1st game, juice, DINK, "
+            "chat/imagine/voice, or server stats. Answer in plain language for "
+            "Discord users — never expose internal implementation details. "
+            "Topics: " + "; ".join(f"'{k}' = {v}" for k, v in TOPICS.items())
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "enum": sorted(TOPICS),
+                    "description": "Documentation topic to retrieve",
+                },
+            },
+            "required": ["topic"],
+        },
+    },
+    {
+        "name": "list_bot_commands",
+        "description": (
+            "List every command the bot currently has registered, grouped by "
+            "feature, with usage and a short description. Use this when someone "
+            "asks what commands exist or how to invoke one."
+        ),
+        "parameters": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "get_first_game_stats",
+        "description": (
+            "Fetch live data for the daily first game: top-10 win leaderboard, "
+            "most recent winner, and the current streak. Use for questions like "
+            "'who is winning firsts' or 'who got first today'."
+        ),
+        "parameters": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "get_dink_ledger",
+        "description": (
+            "Fetch the live DinkCoin ledger: top-10 DINK holders and total DINK "
+            "in circulation. Use for questions about who is richest or how much "
+            "DINK exists."
+        ),
+        "parameters": {"type": "object", "properties": {}},
+    },
+]
+
+
+def build_tool_handlers(bot=None) -> dict:
+    """Map tool names to callables. Handlers take the parsed JSON args dict."""
+    return {
+        "get_bot_documentation": lambda args: get_topic(args.get("topic", "")),
+        "list_bot_commands": lambda args: build_command_reference(bot),
+        "get_first_game_stats": lambda args: get_first_game_stats(bot),
+        "get_dink_ledger": lambda args: get_dink_ledger_stats(bot),
+    }


### PR DESCRIPTION
## Summary
- Adds client-side self-knowledge tools to the Grok integration so `_ask` and `_voice` can answer questions about the bot, the `_1st` game, DINK, and server stats from curated docs and live data instead of guessing.
- Introduces member-facing documentation in `docs/self_knowledge/` and a tool-call loop in `GrokClient` for documentation lookup, command listing, and live first/DINK stats.
- Updates the AI system prompt to speak as Peter Dinklage to server members and avoid revealing internal implementation details.

## Test plan
- [x] `./scripts/test.sh -m "not live"` passes locally (54 tests)
- [x] Live smoke test: `_ask`-style prompt successfully calls `get_bot_documentation` and answers about juice scoring
- [ ] CI GitHub Actions workflow passes on this PR