### PR TITLE
Fix deploy workflow and limit tests to PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
 name: Deploy
 
 on:
-  workflow_run:
-    workflows: [Tests]
-    types: [completed]
+  push:
     branches: [main]
 
 permissions:
@@ -11,14 +9,34 @@ permissions:
 
 jobs:
   restart:
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Restart PebbleHost server
+        env:
+          PEBBLEHOST_API_TOKEN: ${{ secrets.PEBBLEHOST_API_TOKEN }}
+          PEBBLEHOST_SERVER_ID: ${{ secrets.PEBBLEHOST_SERVER_ID }}
         run: |
-          curl -sf -X POST \
-            "https://panel.pebblehost.com/api/client/servers/${{ secrets.PEBBLEHOST_SERVER_ID }}/power" \
-            -H "Authorization: Bearer ${{ secrets.PEBBLEHOST_API_TOKEN }}" \
+          if [ -z "$PEBBLEHOST_API_TOKEN" ] || [ -z "$PEBBLEHOST_SERVER_ID" ]; then
+            echo "Missing required secrets: PEBBLEHOST_API_TOKEN and/or PEBBLEHOST_SERVER_ID"
+            exit 1
+          fi
+
+          response=$(curl -sS -w "\nHTTP_STATUS:%{http_code}" -X POST \
+            "https://panel.pebblehost.com/api/client/servers/${PEBBLEHOST_SERVER_ID}/power" \
+            -H "Authorization: Bearer ${PEBBLEHOST_API_TOKEN}" \
             -H "Content-Type: application/json" \
             -H "Accept: application/json" \
-            -d '{"signal":"restart"}'
+            -d '{"signal":"restart"}')
+
+          body="${response%HTTP_STATUS:*}"
+          status="${response##*HTTP_STATUS:}"
+
+          if [ "$status" != "204" ]; then
+            echo "PebbleHost restart failed (HTTP ${status})"
+            if [ -n "$body" ]; then
+              echo "$body"
+            fi
+            exit 1
+          fi
+
+          echo "PebbleHost restart accepted (HTTP 204)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,31 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Restart PebbleHost server
-        env:
-          PEBBLEHOST_API_TOKEN: ${{ secrets.PEBBLEHOST_API_TOKEN }}
-          PEBBLEHOST_SERVER_ID: ${{ secrets.PEBBLEHOST_SERVER_ID }}
         run: |
-          if [ -z "$PEBBLEHOST_API_TOKEN" ] || [ -z "$PEBBLEHOST_SERVER_ID" ]; then
-            echo "Missing required secrets: PEBBLEHOST_API_TOKEN and/or PEBBLEHOST_SERVER_ID"
-            exit 1
-          fi
-
-          response=$(curl -sS -w "\nHTTP_STATUS:%{http_code}" -X POST \
-            "https://panel.pebblehost.com/api/client/servers/${PEBBLEHOST_SERVER_ID}/power" \
-            -H "Authorization: Bearer ${PEBBLEHOST_API_TOKEN}" \
+          curl -sf -X POST \
+            "https://panel.pebblehost.com/api/client/servers/${{ secrets.PEBBLEHOST_SERVER_ID }}/power" \
+            -H "Authorization: Bearer ${{ secrets.PEBBLEHOST_API_TOKEN }}" \
             -H "Content-Type: application/json" \
             -H "Accept: application/json" \
-            -d '{"signal":"restart"}')
-
-          body="${response%HTTP_STATUS:*}"
-          status="${response##*HTTP_STATUS:}"
-
-          if [ "$status" != "204" ]; then
-            echo "PebbleHost restart failed (HTTP ${status})"
-            if [ -n "$body" ]; then
-              echo "$body"
-            fi
-            exit 1
-          fi
-
-          echo "PebbleHost restart accepted (HTTP 204)"
+            -d '{"signal":"restart"}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 


### PR DESCRIPTION
## Summary
- Remove the `push: main` trigger from the Tests workflow so CI only runs on pull requests.
- Change Deploy to trigger directly on push to `main` (instead of `workflow_run`, which was fragile once tests no longer run on merge).
- Pass PebbleHost secrets via job `env` and print the HTTP status/body when restart fails, so failures are easier to diagnose.

## Test plan
- [ ] Open a PR and confirm the Tests workflow runs
- [ ] Merge to `main` and confirm Tests does **not** run again
- [ ] Confirm Deploy runs on merge and returns HTTP 204
- [ ] If Deploy fails, verify logs show the PebbleHost HTTP status and response body