### PR TITLE
Fix PebbleHost deploy blocked by Cloudflare on GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,9 +14,20 @@ jobs:
     steps:
       - name: Restart PebbleHost server
         run: |
-          curl -sf -X POST \
+          http_code=$(curl -sS -o /tmp/pebblehost-response.txt -w "%{http_code}" -X POST \
             "https://panel.pebblehost.com/api/client/servers/${{ secrets.PEBBLEHOST_SERVER_ID }}/power" \
             -H "Authorization: Bearer ${{ secrets.PEBBLEHOST_API_TOKEN }}" \
             -H "Content-Type: application/json" \
             -H "Accept: application/json" \
-            -d '{"signal":"restart"}'
+            -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0" \
+            -H "Referer: https://panel.pebblehost.com/" \
+            -d '{"signal":"restart"}')
+
+          echo "PebbleHost HTTP status: ${http_code}"
+          if [ -s /tmp/pebblehost-response.txt ]; then
+            cat /tmp/pebblehost-response.txt
+          fi
+
+          if [ "${http_code}" != "204" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- PebbleHost's panel sits behind Cloudflare; GitHub Actions' default `curl` user agent is often blocked with HTTP 403 (shows as curl exit code 22 with `-f`).
- Add browser-like `User-Agent` and `Referer` headers, matching PebbleHost's own API guidance for automated requests.
- Log the HTTP status and response body when restart fails so future errors are visible in Actions logs.
- Add `workflow_dispatch` so you can test deploy manually without merging.

## Test plan
- [ ] Merge this PR
- [ ] Run **Deploy** manually from Actions → **Run workflow**
- [ ] Confirm log shows `PebbleHost HTTP status: 204`
- [ ] Confirm bot restarts and picks up latest code