### PR TITLE
Use custom User-Agent for PebbleHost deploy API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.PEBBLEHOST_API_TOKEN }}" \
             -H "Content-Type: application/json" \
             -H "Accept: application/json" \
-            -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0" \
+            -H "User-Agent: ajkeast-DiscordBot-Deploy/1.0 (GitHub Actions; contact: alexander.keast@gmail.com)" \
             -H "Referer: https://panel.pebblehost.com/" \
             -d '{"signal":"restart"}')
 


### PR DESCRIPTION
## Summary
- Replace the fake Firefox User-Agent with a custom identifier PebbleHost requested for API allowlisting:
  `ajkeast-DiscordBot-Deploy/1.0 (GitHub Actions; contact: alexander.keast@gmail.com)`
- No other deploy behavior changes; still uses existing `PEBBLEHOST_API_TOKEN` and `PEBBLEHOST_SERVER_ID` secrets.

## Test plan
- [ ] Merge this PR to `main`
- [ ] Confirm **Deploy** workflow runs on the merge (or trigger it manually via **Actions → Deploy → Run workflow**)
- [ ] Check logs for `PebbleHost HTTP status: 204`
- [ ] If still 403, reply to PebbleHost with this User-Agent and ask them to allowlist it — we have not tested this User-Agent from GitHub Actions yet

## Note for PebbleHost ticket
Share the User-Agent string above with Dan. Do **not** claim we already tested it from GitHub Actions until after this merge/run.