### PR TITLE
Remove Referer header to fix PebbleHost CSRF 419

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,6 @@ jobs:
             -H "Content-Type: application/json" \
             -H "Accept: application/json" \
             -H "User-Agent: ajkeast-DiscordBot-Deploy/1.0 (GitHub Actions; contact: alexander.keast@gmail.com)" \
-            -H "Referer: https://panel.pebblehost.com/" \
             -d '{"signal":"restart"}')
 
           echo "PebbleHost HTTP status: ${http_code}"


### PR DESCRIPTION
## Summary
- Removes the `Referer: https://panel.pebblehost.com/` header from the deploy workflow curl request
- Keeps the custom User-Agent that PebbleHost asked for
- Addresses the new `419 CSRF token mismatch` error after Cloudflare started allowing the request through

## Why
Bearer API auth should not require CSRF. Sending a panel-origin `Referer` likely caused Laravel to treat the request as a browser session POST instead of an API call.

## Test plan
- [ ] Merge to `main` (or run `workflow_dispatch` after merge)
- [ ] Confirm Deploy workflow gets HTTP `204` instead of `419`
- [ ] Confirm the PebbleHost server restarts