### PR TITLE
Support multi-image _imagine edits

### DIFF
--- a/chatgpt_functions.py
+++ b/chatgpt_functions.py
@@ -194,11 +194,13 @@ class GrokClient:
         )
 
 
-def call_grok_imagine(prompt: str, input_image_url: str | None = None) -> dict:
+def call_grok_imagine(prompt: str, input_image_urls: list[str] | None = None) -> dict:
     """Generate or edit an image using xAI Grok Imagine API (xAI SDK).
 
-    - prompt: Text description for generation, or edit instructions when input_image_url is set.
-    - input_image_url: Optional URL of an image to edit (e.g. Discord CDN URL). Pass as-is; no base64.
+    - prompt: Text description for generation, or edit instructions when input images are set.
+    - input_image_urls: Optional list of image URLs to edit/combine (e.g. Discord CDN URLs).
+      Up to 3 supported by the API. With multiple images, refer to them in the prompt as
+      <IMAGE_0>, <IMAGE_1>, <IMAGE_2>. Pass URLs as-is; no base64.
     - Returns JPEG bytes (base64 from API) so callers can upload to Discord CDN instead of hotlinking.
     """
     try:
@@ -208,8 +210,11 @@ def call_grok_imagine(prompt: str, input_image_url: str | None = None) -> dict:
             "prompt": prompt,
             "image_format": "base64",
         }
-        if input_image_url:
-            sample_kwargs["image_url"] = input_image_url
+        urls = [u for u in (input_image_urls or []) if u]
+        if len(urls) == 1:
+            sample_kwargs["image_url"] = urls[0]
+        elif len(urls) > 1:
+            sample_kwargs["image_urls"] = urls
         response = client.image.sample(**sample_kwargs)
         if not response.image:
             raise ValueError("Grok Imagine response did not include image data")

--- a/cogs/ai.py
+++ b/cogs/ai.py
@@ -1,6 +1,6 @@
 from discord.ext import commands
 from chatgpt_functions import GrokClient, call_grok_imagine, GROK_IMAGINE_FILENAME
-from utils.constants import EMBED_COLOR, MAX_GROK_SESSION_TURNS
+from utils.constants import EMBED_COLOR, MAX_GROK_SESSION_TURNS, MAX_IMAGINE_INPUT_IMAGES
 from utils.db import db_ops
 import discord
 import requests
@@ -78,19 +78,30 @@ class AI(commands.Cog):
 
     @commands.command()
     async def imagine(self, ctx, *, arg, pass_context=True, brief="Generate AI Art"):
-        """Generate an AI image using Grok Imagine (xAI). Logged to DB."""
+        """Generate an AI image using Grok Imagine (xAI). Logged to DB.
+
+        Attach up to 3 images to edit or combine them; refer to attachments in the
+        prompt as <IMAGE_0>, <IMAGE_1>, <IMAGE_2> (attachment order).
+        """
 
         db_ops.write_dalle_entry(user_id=ctx.author.id, prompt=arg, message_id=ctx.message.id)
 
-        # Optional: first image attachment URL used as input for editing
-        input_image_url = None
-        for a in ctx.message.attachments:
-            if a.content_type and a.content_type.startswith("image/"):
-                input_image_url = a.url
-                break
+        input_image_urls = [
+            a.url
+            for a in ctx.message.attachments
+            if a.content_type and a.content_type.startswith("image/")
+        ]
+        if len(input_image_urls) > MAX_IMAGINE_INPUT_IMAGES:
+            await ctx.send(
+                f"You can attach at most {MAX_IMAGINE_INPUT_IMAGES} images for `_imagine`."
+            )
+            return
 
         async with ctx.typing():
-            response = call_grok_imagine(arg, input_image_url=input_image_url)
+            response = call_grok_imagine(
+                arg,
+                input_image_urls=input_image_urls or None,
+            )
 
             if response["status"] == "success":
                 image_file = discord.File(
@@ -100,6 +111,13 @@ class AI(commands.Cog):
                 embed = discord.Embed(title="🎨 AI Generated Image", color=EMBED_COLOR)
                 embed.set_image(url=f"attachment://{GROK_IMAGINE_FILENAME}")
                 embed.add_field(name="Prompt", value=arg, inline=False)
+                if input_image_urls:
+                    refs = ", ".join(f"<IMAGE_{i}>" for i in range(len(input_image_urls)))
+                    embed.add_field(
+                        name="Input images",
+                        value=f"{len(input_image_urls)} attached ({refs})",
+                        inline=False,
+                    )
                 embed.set_footer(text=f"Requested by {ctx.author.display_name}")
                 await ctx.send(embed=embed, file=image_file)
             else:

--- a/docs/self_knowledge/ai_features.md
+++ b/docs/self_knowledge/ai_features.md
@@ -17,7 +17,10 @@ These are your AI-powered features. When explaining them to members, focus on
 ## Image generation — `_imagine <prompt>`
 
 - Describe what you want and the bot generates an image.
-- Attach an image to the command to use it as a starting point for edits.
+- Attach **1–3 images** to edit or combine them (API limit is three).
+- With multiple attachments, refer to them in order as `<IMAGE_0>`, `<IMAGE_1>`,
+  and `<IMAGE_2>` in your prompt (e.g. “put the person from `<IMAGE_0>` into the
+  scene from `<IMAGE_1>`”).
 
 ## Voice — `_voice <prompt>`
 
@@ -31,7 +34,8 @@ These are your AI-powered features. When explaining them to members, focus on
 
 ## Tips for members
 
-- Be specific in prompts for better `_imagine` results.
+- Be specific in prompts for better `_imagine` results. When combining photos,
+  name which attachment is which with `<IMAGE_0>` / `<IMAGE_1>` / `<IMAGE_2>`.
 - If the bot seems stuck on an old topic, someone can run `_clear`.
 - `_ask` works best for questions; `_imagine` is for pictures; `_voice` is when
   they want to hear a reply.

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -4,6 +4,14 @@ from unittest.mock import MagicMock, patch
 
 from cogs.ai import AI
 from tests.reporting import SECTION_COMMANDS
+from utils.constants import MAX_IMAGINE_INPUT_IMAGES
+
+
+def _image_attachment(url: str) -> MagicMock:
+    attachment = MagicMock()
+    attachment.url = url
+    attachment.content_type = "image/png"
+    return attachment
 
 
 async def test_ask_success(report, ai_cog, mock_ctx):
@@ -67,8 +75,51 @@ async def test_imagine_success(mock_imagine, report, mock_db_ops, ai_cog, mock_c
     report.record("db write", "write_dalle_entry called", mock_db_ops.write_dalle_entry.called, section=SECTION_COMMANDS)
 
     mock_db_ops.write_dalle_entry.assert_called_once()
+    mock_imagine.assert_called_once_with("a red circle", input_image_urls=None)
     mock_ctx.send.assert_awaited_once()
     assert sent_file is not None
+
+
+@patch("cogs.ai.call_grok_imagine")
+async def test_imagine_with_multiple_input_images(mock_imagine, report, mock_db_ops, ai_cog, mock_ctx):
+    urls = [
+        "https://cdn.discordapp.com/attachments/1/a.png",
+        "https://cdn.discordapp.com/attachments/1/b.png",
+    ]
+    mock_ctx.message.attachments = [_image_attachment(u) for u in urls]
+    mock_imagine.return_value = {
+        "status": "success",
+        "image_bytes": b"fake-jpeg-bytes",
+        "revised_prompt": None,
+    }
+
+    prompt = "Put the person from <IMAGE_0> into the scene from <IMAGE_1>"
+    await ai_cog.imagine.callback(ai_cog, mock_ctx, arg=prompt)
+
+    mock_imagine.assert_called_once_with(prompt, input_image_urls=urls)
+    embed = mock_ctx.send.call_args.kwargs["embed"]
+    input_field = next(f for f in embed.fields if f.name == "Input images")
+    report.record("input image count", "2 attached", input_field.value, section=SECTION_COMMANDS)
+    assert "2 attached" in input_field.value
+    assert "<IMAGE_0>" in input_field.value
+    assert "<IMAGE_1>" in input_field.value
+    mock_ctx.send.assert_awaited_once()
+
+
+@patch("cogs.ai.call_grok_imagine")
+async def test_imagine_rejects_too_many_images(mock_imagine, report, mock_db_ops, ai_cog, mock_ctx):
+    mock_ctx.message.attachments = [
+        _image_attachment(f"https://cdn.discordapp.com/attachments/1/{i}.png")
+        for i in range(MAX_IMAGINE_INPUT_IMAGES + 1)
+    ]
+
+    await ai_cog.imagine.callback(ai_cog, mock_ctx, arg="combine these")
+
+    expected = f"You can attach at most {MAX_IMAGINE_INPUT_IMAGES} images for `_imagine`."
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("too many images message", expected, actual, section=SECTION_COMMANDS)
+    mock_imagine.assert_not_called()
+    mock_ctx.send.assert_awaited_once_with(expected)
 
 
 @patch("cogs.ai.call_grok_imagine")

--- a/tests/test_call_grok_imagine.py
+++ b/tests/test_call_grok_imagine.py
@@ -1,0 +1,61 @@
+"""Unit tests for call_grok_imagine image input routing."""
+
+from unittest.mock import MagicMock, patch
+
+from chatgpt_functions import call_grok_imagine
+from tests.reporting import SECTION_COMMANDS
+
+
+@patch("chatgpt_functions.Client")
+def test_call_grok_imagine_no_images(mock_client_cls, report):
+    mock_client = MagicMock()
+    mock_client_cls.return_value = mock_client
+    mock_client.image.sample.return_value = MagicMock(image=b"jpeg")
+
+    result = call_grok_imagine("a cat")
+
+    kwargs = mock_client.image.sample.call_args.kwargs
+    report.record("image_url", None, kwargs.get("image_url"), section=SECTION_COMMANDS)
+    report.record("image_urls", None, kwargs.get("image_urls"), section=SECTION_COMMANDS)
+    assert "image_url" not in kwargs
+    assert "image_urls" not in kwargs
+    assert result["status"] == "success"
+
+
+@patch("chatgpt_functions.Client")
+def test_call_grok_imagine_single_image_uses_image_url(mock_client_cls, report):
+    mock_client = MagicMock()
+    mock_client_cls.return_value = mock_client
+    mock_client.image.sample.return_value = MagicMock(image=b"jpeg")
+    url = "https://cdn.example.com/a.png"
+
+    result = call_grok_imagine("edit this", input_image_urls=[url])
+
+    kwargs = mock_client.image.sample.call_args.kwargs
+    report.record("image_url", url, kwargs.get("image_url"), section=SECTION_COMMANDS)
+    assert kwargs["image_url"] == url
+    assert "image_urls" not in kwargs
+    assert result["status"] == "success"
+
+
+@patch("chatgpt_functions.Client")
+def test_call_grok_imagine_multiple_images_uses_image_urls(mock_client_cls, report):
+    mock_client = MagicMock()
+    mock_client_cls.return_value = mock_client
+    mock_client.image.sample.return_value = MagicMock(image=b"jpeg")
+    urls = [
+        "https://cdn.example.com/a.png",
+        "https://cdn.example.com/b.png",
+        "https://cdn.example.com/c.png",
+    ]
+
+    result = call_grok_imagine(
+        "Combine <IMAGE_0> and <IMAGE_1> with style from <IMAGE_2>",
+        input_image_urls=urls,
+    )
+
+    kwargs = mock_client.image.sample.call_args.kwargs
+    report.record("image_urls count", 3, len(kwargs.get("image_urls") or []), section=SECTION_COMMANDS)
+    assert kwargs["image_urls"] == urls
+    assert "image_url" not in kwargs
+    assert result["status"] == "success"

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -17,5 +17,8 @@ BOT_USER_ID = 908765514753531934
 # Limits context growth and cost; each turn adds more tokens to the stored session.
 MAX_GROK_SESSION_TURNS = 20
 
+# Grok Imagine multi-reference edit limit (xAI API: up to 3 source images).
+MAX_IMAGINE_INPUT_IMAGES = 3
+
 # DINK awarded for each successful _1st claim (MySQL ledger only)
 DINK_MINT_AMOUNT = float(os.getenv("DINK_MINT_AMOUNT", "1"))


### PR DESCRIPTION
## Summary
- `_imagine` now accepts up to **3** image attachments and forwards them to Grok Imagine’s multi-reference edit API (`image_urls`).
- Single-image edits still use `image_url`; text-only generation is unchanged.
- Self-knowledge docs and unit tests cover multi-image routing and the 3-image limit.

## Test plan
- [ ] `_imagine a red circle` with no attachments still generates an image
- [ ] `_imagine` with **1** attached image edits that image
- [ ] `_imagine Put <IMAGE_0> into <IMAGE_1>` with **2** attachments combines them
- [ ] Attaching **4** images returns the “at most 3” error and does not call the API
- [ ] CI unit tests pass (`tests/test_ai_commands.py`, `tests/test_call_grok_imagine.py`)