### PR TITLE
Simplify _imagine input images embed field

### DIFF
--- a/cogs/ai.py
+++ b/cogs/ai.py
@@ -112,10 +112,10 @@ class AI(commands.Cog):
                 embed.set_image(url=f"attachment://{GROK_IMAGINE_FILENAME}")
                 embed.add_field(name="Prompt", value=arg, inline=False)
                 if input_image_urls:
-                    refs = ", ".join(f"<IMAGE_{i}>" for i in range(len(input_image_urls)))
+                    count = len(input_image_urls)
                     embed.add_field(
                         name="Input images",
-                        value=f"{len(input_image_urls)} attached ({refs})",
+                        value=f"{count} attached",
                         inline=False,
                     )
                 embed.set_footer(text=f"Requested by {ctx.author.display_name}")

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -100,9 +100,7 @@ async def test_imagine_with_multiple_input_images(mock_imagine, report, mock_db_
     embed = mock_ctx.send.call_args.kwargs["embed"]
     input_field = next(f for f in embed.fields if f.name == "Input images")
     report.record("input image count", "2 attached", input_field.value, section=SECTION_COMMANDS)
-    assert "2 attached" in input_field.value
-    assert "<IMAGE_0>" in input_field.value
-    assert "<IMAGE_1>" in input_field.value
+    assert input_field.value == "2 attached"
     mock_ctx.send.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary
- `_imagine` success embeds now show only the input image count (e.g. `2 attached`).
- Removes the `<IMAGE_0>`, `<IMAGE_1>` labels from the embed field.

## Test plan
- [ ] `_imagine` with 2 attachments shows `Input images: 2 attached`
- [ ] Prompt docs still mention `<IMAGE_N>` for users who want to reference specific attachments