### PR TITLE
Harden first-game edge cases, error handling, and help text

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,6 +2,7 @@
 import asyncio
 import discord                          # Discord API
 from discord.ext import commands
+import math
 import os                              # For environment variables
 import logging
 import sys
@@ -55,6 +56,13 @@ class DinkBot(commands.Bot):
 
     async def on_command_error(self, ctx, error):
         if isinstance(error, commands.CommandNotFound):
+            return
+        if isinstance(error, commands.CommandOnCooldown):
+            minutes = max(1, math.ceil(error.retry_after / 60))
+            await ctx.send(
+                f"You've hit the `_imagine` limit (30 per hour). "
+                f"Try again in about {minutes} minute{'s' if minutes != 1 else ''}."
+            )
             return
         logger = logging.getLogger(__name__)
         logger.exception("Command error in %s: %s", getattr(ctx.command, "name", "?"), error)

--- a/chatgpt_functions.py
+++ b/chatgpt_functions.py
@@ -226,4 +226,5 @@ def call_grok_imagine(prompt: str, input_image_urls: list[str] | None = None) ->
             "revised_prompt": None,
         }
     except Exception as e:
+        logger.exception("Grok Imagine failed")
         return {"status": "error", "error": str(e)}

--- a/cogs/ai.py
+++ b/cogs/ai.py
@@ -1,6 +1,12 @@
 from discord.ext import commands
 from chatgpt_functions import GrokClient, call_grok_imagine, GROK_IMAGINE_FILENAME
-from utils.constants import EMBED_COLOR, MAX_GROK_SESSION_TURNS, MAX_IMAGINE_INPUT_IMAGES
+from utils.constants import (
+    EMBED_COLOR,
+    IMAGINE_RATE_LIMIT,
+    IMAGINE_RATE_PERIOD_SECONDS,
+    MAX_GROK_SESSION_TURNS,
+    MAX_IMAGINE_INPUT_IMAGES,
+)
 from utils.db import db_ops
 import discord
 import requests
@@ -12,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class AI(commands.Cog):
-    """AI features: Grok chat (Responses API, stateful on xAI) and Grok Imagine image generation."""
+    """Chat, image generation, and voice."""
 
     def __init__(self, bot):
         self.bot = bot
@@ -40,9 +46,9 @@ class AI(commands.Cog):
             "Do not use markdown bold (**text**) for whole responses or multiple sentences—especially after web search. "
         )
 
-    @commands.command()
-    async def ask(self, ctx, *, arg, pass_context=True, brief="Ask Grok"):
-        """Ask Grok (stateful conversation, native search). Supports image attachments."""
+    @commands.command(brief="Ask a question")
+    async def ask(self, ctx, *, arg):
+        """Ask a question. You can also attach images."""
 
         image_urls = [
             a.url
@@ -76,12 +82,13 @@ class AI(commands.Cog):
 
             await ctx.send(response_text or "Sorry, I couldn't generate a reply this time. Please try again.")
 
-    @commands.command()
-    async def imagine(self, ctx, *, arg, pass_context=True, brief="Generate AI Art"):
-        """Generate an AI image using Grok Imagine (xAI). Logged to DB.
+    @commands.command(brief="Generate an AI image")
+    @commands.cooldown(IMAGINE_RATE_LIMIT, IMAGINE_RATE_PERIOD_SECONDS, commands.BucketType.user)
+    async def imagine(self, ctx, *, arg):
+        """Generate an AI image based on a prompt and optional input images.
 
-        Attach up to 3 images to edit or combine them; refer to attachments in the
-        prompt as <IMAGE_0>, <IMAGE_1>, <IMAGE_2> (attachment order).
+        Attach up to 3 images to edit or combine them; refer to them in the prompt
+        as <IMAGE_0>, <IMAGE_1>, <IMAGE_2> (attachment order).
         """
 
         db_ops.write_dalle_entry(user_id=ctx.author.id, prompt=arg, message_id=ctx.message.id)
@@ -121,25 +128,26 @@ class AI(commands.Cog):
                 embed.set_footer(text=f"Requested by {ctx.author.display_name}")
                 await ctx.send(embed=embed, file=image_file)
             else:
+                logger.error("_imagine failed: %s", response.get("error"))
                 await ctx.send(
                     embed=discord.Embed(
                         title="❌ Error",
-                        description=f"Failed to generate image: {response['error']}",
+                        description="Failed to generate image. Check the bot logs and try again.",
                         color=EMBED_COLOR,
                     )
                 )
 
-    @commands.command()
-    async def clear(self, ctx, pass_context=True, brief="Clear chat session"):
-        """Clear the shared Grok conversation session so the next _ask starts fresh."""
+    @commands.command(brief="Clear the shared chat")
+    async def clear(self, ctx):
+        """Clear the shared chat so the next _ask starts fresh."""
 
         self.last_response_id = None
         self._session_turns = 0
         await ctx.send("Chat history cleared! Starting fresh, dude! 🤙")
 
-    @commands.command()
-    async def voice(self, ctx, *, text, pass_context=True, brief="Text to Speech"):
-        """Generate a Grok response to the prompt, then convert that reply to speech."""
+    @commands.command(brief="Answer a prompt out loud")
+    async def voice(self, ctx, *, text):
+        """Answer a prompt and read the reply aloud."""
 
         if not text:
             await ctx.send("Please provide text to convert to speech.")
@@ -197,10 +205,12 @@ class AI(commands.Cog):
 
                 await ctx.send(file=audio_file)
 
-            except requests.exceptions.RequestException as e:
-                await ctx.send(f"Error generating speech: {str(e)}")
-            except Exception as e:
-                await ctx.send(f"An error occurred: {str(e)}")
+            except requests.exceptions.RequestException:
+                logger.exception("_voice TTS request failed for user %s", ctx.author.id)
+                await ctx.send("Something broke generating speech. Check the bot logs and try again.")
+            except Exception:
+                logger.exception("_voice failed for user %s", ctx.author.id)
+                await ctx.send("Something broke on my end, dude. Check the bot logs and try again.")
 
 
 async def setup(bot):

--- a/cogs/dinkcoin.py
+++ b/cogs/dinkcoin.py
@@ -10,20 +10,20 @@ logger = logging.getLogger(__name__)
 
 
 class DinkCoin(commands.Cog):
-    """DinkCoin balance, ledger, and peer-to-peer transfers (MySQL ledger)."""
+    """DinkCoin balances and transfers."""
 
     def __init__(self, bot):
         self.bot = bot
 
     @commands.command(brief="Check your DINK balance")
     async def balance(self, ctx):
-        """Show the caller's DINK balance."""
+        """Show your DINK balance."""
         balance = db_ops.get_dink_balance(ctx.author.id)
         await ctx.send(f"{ctx.author.mention} has **{balance:g} DINK**")
 
-    @commands.command(brief="View the DINK leaderboard")
+    @commands.command(brief="Show the DINK leaderboard")
     async def ledger(self, ctx, limit: int = 10):
-        """Show top DINK holders in the server."""
+        """Show the DINK leaderboard."""
         limit = min(max(limit, 1), 20)
         df = db_ops.get_dink_ledger(limit)
         total = db_ops.get_total_dink_circulation()
@@ -55,7 +55,7 @@ class DinkCoin(commands.Cog):
 
     @commands.command(brief="Send DINK to another user")
     async def pay(self, ctx, member: discord.Member, amount: float):
-        """Transfer whole DINK coins to another user. Usage: `_pay @user <amount>`"""
+        """Send DINK to another user. Usage: `_pay @user <amount>`"""
         if member.bot:
             await ctx.send("You cannot pay bots.")
             return

--- a/cogs/first.py
+++ b/cogs/first.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 import asyncio
 import io
+import logging
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 from datetime import datetime
@@ -9,23 +10,17 @@ import pytz
 from utils.db import db_ops, streak_calc, juice_calc
 from utils.constants import GENERAL_CHANNEL_ID, EMBED_COLOR, DINK_MINT_AMOUNT
 
+logger = logging.getLogger(__name__)
+
 class First(commands.Cog):
-    """A cog that manages the daily 'first' claiming game and related statistics."""
+    """Daily firsts game and related stats."""
     
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(name='1st', brief='Claim your first today')
+    @commands.command(name='1st', brief='Claim first for today')
     async def first(self, ctx):
-        """Attempt to claim first place for the day.
-        
-        Args:
-            ctx: The command context
-            
-        The command only works in the designated general channel.
-        First can only be claimed once per day (Eastern Time).
-        Successful claims are recorded in the database.
-        """
+        """Claim first for today. Only works in #general, once per day."""
         # Checks if first has been claimed, if not, writes user_id and timestamp to SQL database
         channel_id = GENERAL_CHANNEL_ID    # dinkscord general text-channel id
         if ctx.channel.id != channel_id:
@@ -36,10 +31,13 @@ class First(commands.Cog):
             utc_now = pytz.timezone('UTC').localize(utc_now).astimezone(pytz.timezone('US/Eastern'))
 
             df = db_ops.get_table_data('firstlist_id')
-            timestamp_most_recent = df['timesent'].iloc[-1].to_pydatetime()
-            timestamp_most_recent = pytz.timezone('UTC').localize(timestamp_most_recent).astimezone(pytz.timezone('US/Eastern'))
-            
-            if utc_now.strftime("%Y-%m-%d") == timestamp_most_recent.strftime("%Y-%m-%d"):
+            already_claimed = False
+            if not df.empty:
+                timestamp_most_recent = df['timesent'].iloc[-1].to_pydatetime()
+                timestamp_most_recent = pytz.timezone('UTC').localize(timestamp_most_recent).astimezone(pytz.timezone('US/Eastern'))
+                already_claimed = utc_now.strftime("%Y-%m-%d") == timestamp_most_recent.strftime("%Y-%m-%d")
+
+            if already_claimed:
                 Author = ctx.author.mention
                 msg = f'Sorry {Author}, first has already been claimed today. 😭'
                 await ctx.channel.send(msg)
@@ -51,23 +49,19 @@ class First(commands.Cog):
                 msg = f"{Author} is first today! 🥳 +{DINK_MINT_AMOUNT:g} **DINK**"
                 await ctx.channel.send(msg)
 
-    @commands.command()
-    async def score(self, ctx, pass_context=True, brief='Count of daily 1st wins'):
-        """Display the leaderboard of first place claims.
-        
-        Args:
-            ctx: The command context
-            
-        Shows:
-        - Top 5 users by number of first place claims
-        - Most recent winner and their current streak
-        """
+    @commands.command(brief='Show the firsts leaderboard')
+    async def score(self, ctx):
+        """Show the firsts leaderboard and current streak."""
         # reads SQL database and generates an embed with list of names and scores
         df = db_ops.get_table_data('firstlist_id')
+        if df.empty:
+            await ctx.channel.send("No firsts recorded yet — claim one with `_1st`!")
+            return
+
         streak = streak_calc.calculate_streak(df)
         counts = df.user_id.value_counts()
         embed=discord.Embed(title='First Leaderboard',description="Count of daily 1st wins",color=EMBED_COLOR)
-        for i in range(5):  # display top 5
+        for i in range(min(5, len(counts))):
             embed.add_field(name=self.bot.get_user(int(counts.index[i])),
                             value=counts.iloc[i],
                             inline=False)
@@ -75,19 +69,9 @@ class First(commands.Cog):
         embed.set_footer(text=txt)
         await ctx.channel.send(embed=embed)
 
-    @commands.command()
-    async def stats(self, ctx, *, args=None, pass_context=True, brief='Get an individual users stats'):
-        """Display detailed statistics for a specific user.
-        
-        Args:
-            ctx: The command context
-            args: Optional mention of another user to view their stats
-            
-        Shows:
-        - Total first place claims (Score)
-        - Juice score (minutes since midnight, rolling over missed days)
-        - Longest streak of consecutive first places
-        """
+    @commands.command(brief='Show firsts stats for a user')
+    async def stats(self, ctx, *, args=None):
+        """Show score, juice, and streak for you or a mentioned user."""
         # reads SQL database and generates an embed with list of names and scores
         df = db_ops.get_table_data('firstlist_id')
 
@@ -114,33 +98,26 @@ class First(commands.Cog):
             embed.add_field(name="Juice", value=f'{int(juice)} 🧃', inline=True)
             embed.add_field(name="Longest streak", value=f'{streak} days 🔥', inline=True)
 
-            print(str(author.display_avatar.with_size(128)))
             await ctx.channel.send(embed=embed)
-        except ValueError as ve:
-            print(f"ValueError in stats command: {str(ve)}")
+        except ValueError:
+            logger.exception("Invalid user ID in stats command: %s", author_id)
             await ctx.channel.send('Error: Invalid user ID format.')
-        except Exception as e:
-            print(f"Unexpected error in stats command: {type(e).__name__}: {str(e)}")
+        except Exception:
+            logger.exception("Unexpected error in stats command for user %s", author_id)
             await ctx.channel.send('An unexpected error occurred while fetching stats.')
 
-    @commands.command()
-    async def juice(self, ctx, pass_context=True, brief='Get the server juice scores'):
-        """Display the juice leaderboard showing time efficiency of first claims.
-        
-        Args:
-            ctx: The command context
-            
-        Shows:
-        - Top 5 users by total juice score
-        - The highest single-day juice score and its holder
-        
-        Juice score is minutes since midnight Eastern, with missed days rolling over.
-        """
+    @commands.command(brief='Show the juice leaderboard')
+    async def juice(self, ctx):
+        """Show the juice leaderboard and one-day high score."""
         df = db_ops.get_table_data('firstlist_id')
+        if df.empty:
+            await ctx.channel.send("No firsts recorded yet — claim one with `_1st`!")
+            return
+
         juice_df, highscore_user_id, highscore_value = juice_calc.calculate_juice(df)
         
         embed=discord.Embed(title='Juice Board 🧃',description='Total minutes between _1st and midnight 🧃',color=EMBED_COLOR)
-        for i in range(5):
+        for i in range(min(5, len(juice_df))):
             embed.add_field(name=self.bot.get_user(int(juice_df.iloc[i]['user_id'])),
                           value=int(juice_df.iloc[i]['juice']),
                           inline=False)
@@ -148,12 +125,12 @@ class First(commands.Cog):
         embed.set_footer(text=txt)
         await ctx.channel.send(embed=embed)
 
-    @commands.command()
-    async def graph(self, ctx, brief='Get a graph of the firsts to date'):
-        """Generate and send a graph showing the progression of first claims over time."""
+    @commands.command(brief='Graph firsts over time')
+    async def graph(self, ctx):
+        """Graph firsts over time."""
         df_first = db_ops.get_table_data('firstlist_id')
         if df_first.empty:
-            await ctx.send("No firsts recorded yet — claim one with `!1st`!")
+            await ctx.send("No firsts recorded yet — claim one with `_1st`!")
             return
 
         df_first['_1st to date'] = df_first.groupby('user_id').cumcount() + 1
@@ -191,9 +168,9 @@ class First(commands.Cog):
         embed.set_image(url="attachment://first_graph.png")
         await ctx.send(embed=embed, file=discord.File(data_stream, filename="first_graph.png"))
 
-    @commands.command()
-    async def juicegraph(self, ctx, brief='Get a graph of daily juice over time'):
-        """Generate and send a graph showing daily juice scores over time."""
+    @commands.command(brief='Graph daily juice over time')
+    async def juicegraph(self, ctx):
+        """Graph daily juice over time."""
         df_first = db_ops.get_table_data('firstlist_id')
         if df_first.empty:
             await ctx.send("No firsts recorded yet — claim one with `_1st`!")

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -2,24 +2,14 @@ import discord
 from discord.ext import commands
 
 class Misc(commands.Cog):
-    """A cog containing miscellaneous utility commands."""
+    """Miscellaneous commands."""
     
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command()
-    async def donation(self, ctx, brief='Get a list of all donations'):
-        """Display a list of all donations made to support the bot.
-        
-        Args:
-            ctx: The command context
-            
-        Shows an embed containing:
-        - Names of donors
-        - Amount donated by each person
-        - Total contribution from each donor
-        """
-        # provides embed of all donations
+    @commands.command(brief='Show the donation board')
+    async def donation(self, ctx):
+        """Show the donation board."""
         embed=discord.Embed(title='Donation Board',description='Thank you to our generous patrons!',color=0x4d4170)
         embed.add_field(name='Matt',value=f'${(6.00+8.91+6.96+6.00):.2f}',inline=False)
         embed.add_field(name='Sammy T',value=f'${(6.90+14.20+6.00):.2f}',inline=False)

--- a/cogs/server.py
+++ b/cogs/server.py
@@ -3,11 +3,14 @@ from discord.ext import commands, tasks
 from utils.db import db_ops
 from utils.constants import GENERAL_CHANNEL_ID, EMBED_COLOR
 from datetime import datetime, timedelta
+import logging
 import pytz
 import asyncio
 
+logger = logging.getLogger(__name__)
+
 class Server(commands.Cog):
-    """A cog for managing and tracking server-related information and updates."""
+    """Server info sync and monthly activity report."""
     
     def __init__(self, bot):
         self.bot = bot
@@ -61,7 +64,10 @@ class Server(commands.Cog):
                 try:
                     await channel.send(embed=embed)
                 except discord.Forbidden:
-                    print(f"Bot doesn't have permission to send messages in channel {GENERAL_CHANNEL_ID}")
+                    logger.warning(
+                        "Bot doesn't have permission to send messages in channel %s",
+                        GENERAL_CHANNEL_ID,
+                    )
 
     @monthly_stats.before_loop
     async def before_monthly_stats(self):
@@ -74,21 +80,9 @@ class Server(commands.Cog):
         seconds_until_next_hour = (next_hour - now).total_seconds()
         await asyncio.sleep(seconds_until_next_hour)
 
-    @commands.command()
+    @commands.command(brief='Refresh member info for the dashboard')
     async def members(self, ctx):
-        """Update the database with current server member information.
-        
-        Args:
-            ctx: The command context
-            
-        Stores for each member:
-        - User ID
-        - Username
-        - Display name (nickname)
-        - Avatar URL
-        - Account creation date
-        """
-        # updates database with all current members of the server and their info
+        """Refresh member info for the dashboard."""
         members = ctx.guild.members
         member_data = []
         for member in members:
@@ -103,21 +97,9 @@ class Server(commands.Cog):
         db_ops.update_members(member_data)
         await ctx.channel.send("Member info successfully updated.")
 
-    @commands.command()
+    @commands.command(brief='Refresh emoji info for the dashboard')
     async def emojis(self, ctx):
-        """Update the database with current server emoji information.
-        
-        Args:
-            ctx: The command context
-            
-        Stores for each emoji:
-        - Emoji ID
-        - Name
-        - Guild ID
-        - Image URL
-        - Creation date
-        """
-        # updates database with all current emojis in the server
+        """Refresh emoji info for the dashboard."""
         emoji_data = []
         for emoji in ctx.guild.emojis:
             id = emoji.id
@@ -130,19 +112,9 @@ class Server(commands.Cog):
         db_ops.update_emojis(emoji_data)
         await ctx.channel.send("Emoji info successfully updated.")
 
-    @commands.command()
+    @commands.command(brief='Refresh channel info for the dashboard')
     async def channels(self, ctx):
-        """Update the database with current server channel information.
-        
-        Args:
-            ctx: The command context
-            
-        Stores for each channel:
-        - Channel ID
-        - Channel name
-        - Creation date
-        """
-        # updates database with all current channels on the server
+        """Refresh channel info for the dashboard."""
         channel_data = []
         for channel in ctx.guild.channels:
             id = channel.id

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1,44 +1,26 @@
 from discord.ext import commands
 
 class Utility(commands.Cog):
-    """A cog containing basic utility commands for user interaction."""
+    """Simple utility commands."""
     
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(pass_context=True)
+    @commands.command(brief='Say hello')
     async def hello(self, ctx):
-        """Send a friendly greeting mentioning the user.
-        
-        Args:
-            ctx: The command context
-        """
-        # response with name of the message author
+        """Say hello."""
         Author = ctx.author.mention
         msg = f'Hello {Author}!'
         await ctx.channel.send(msg)
 
-    @commands.command()
-    async def ping(self, ctx, brief='Ping the bot'):
-        """Check if the bot is responsive.
-        
-        Args:
-            ctx: The command context
-            
-        Responds with 'pong' to indicate the bot is active.
-        """
-        # response with pong
+    @commands.command(brief='Check if the bot is online')
+    async def ping(self, ctx):
+        """Check if the bot is online."""
         await ctx.channel.send('pong')
 
-    @commands.command()
-    async def simonsays(self, ctx, *, arg, pass_context=True, brief='I will repeat after you'):
-        """Repeat the message sent by the user.
-        
-        Args:
-            ctx: The command context
-            arg: The message to repeat
-        """
-        # repeats string back
+    @commands.command(brief='Make the bot repeat your message')
+    async def simonsays(self, ctx, *, arg):
+        """Make the bot repeat your message."""
         await ctx.channel.send(arg)
 
 async def setup(bot):

--- a/docs/self_knowledge/ai_features.md
+++ b/docs/self_knowledge/ai_features.md
@@ -17,7 +17,7 @@ These are your AI-powered features. When explaining them to members, focus on
 ## Image generation — `_imagine <prompt>`
 
 - Describe what you want and the bot generates an image.
-- Attach **1–3 images** to edit or combine them (API limit is three).
+- Attach **1–3 images** to edit or combine them.
 - With multiple attachments, refer to them in order as `<IMAGE_0>`, `<IMAGE_1>`,
   and `<IMAGE_2>` in your prompt (e.g. “put the person from `<IMAGE_0>` into the
   scene from `<IMAGE_1>`”).

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -1,11 +1,17 @@
 """Mocked tests for AI cog commands."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from discord.ext import commands
+
+from bot import DinkBot
 from cogs.ai import AI
 from tests.reporting import SECTION_COMMANDS
-from utils.constants import MAX_IMAGINE_INPUT_IMAGES
-
+from utils.constants import (
+    IMAGINE_RATE_LIMIT,
+    IMAGINE_RATE_PERIOD_SECONDS,
+    MAX_IMAGINE_INPUT_IMAGES,
+)
 
 def _image_attachment(url: str) -> MagicMock:
     attachment = MagicMock()
@@ -127,11 +133,45 @@ async def test_imagine_failure(mock_imagine, report, ai_cog, mock_ctx):
     await ai_cog.imagine.callback(ai_cog, mock_ctx, arg="a red circle")
 
     embed = mock_ctx.send.call_args.kwargs["embed"]
+    expected_desc = "Failed to generate image. Check the bot logs and try again."
     report.record("embed title", "Error", embed.title, section=SECTION_COMMANDS)
-    report.record("error detail", "rate limited", mock_imagine.return_value["error"], section=SECTION_COMMANDS)
+    report.record("embed description", expected_desc, embed.description, section=SECTION_COMMANDS)
 
     mock_ctx.send.assert_awaited_once()
     assert embed.title == "❌ Error"
+    assert embed.description == expected_desc
+    assert "rate limited" not in (embed.description or "")
+
+
+def test_imagine_has_hourly_rate_limit(report, ai_cog):
+    buckets = ai_cog.imagine._buckets
+    cooldown = buckets._cooldown
+    report.record("rate", IMAGINE_RATE_LIMIT, cooldown.rate, section=SECTION_COMMANDS)
+    report.record("per seconds", IMAGINE_RATE_PERIOD_SECONDS, cooldown.per, section=SECTION_COMMANDS)
+    report.record("bucket type", commands.BucketType.user, buckets.type, section=SECTION_COMMANDS)
+    assert cooldown.rate == IMAGINE_RATE_LIMIT
+    assert cooldown.per == IMAGINE_RATE_PERIOD_SECONDS
+    assert buckets.type == commands.BucketType.user
+
+
+async def test_imagine_cooldown_error_message(report, mock_ctx):
+    expected = (
+        "You've hit the `_imagine` limit (30 per hour). "
+        "Try again in about 4 minutes."
+    )
+    bot = DinkBot.__new__(DinkBot)
+    error = commands.CommandOnCooldown(
+        cooldown=commands.Cooldown(IMAGINE_RATE_LIMIT, IMAGINE_RATE_PERIOD_SECONDS),
+        retry_after=240.0,
+        type=commands.BucketType.user,
+    )
+    mock_ctx.send = AsyncMock()
+
+    await DinkBot.on_command_error(bot, mock_ctx, error)
+
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("cooldown message", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.send.assert_awaited_once_with(expected)
 
 
 @patch("cogs.ai.requests.post")
@@ -163,3 +203,20 @@ async def test_voice_missing_api_key(_mock_getenv, report, ai_cog, mock_ctx):
     actual = mock_ctx.send.call_args.args[0]
     report.record("error message", expected, actual, section=SECTION_COMMANDS)
     mock_ctx.send.assert_awaited_once_with(expected)
+
+
+@patch("cogs.ai.requests.post")
+@patch("cogs.ai.os.getenv", return_value="test-key")
+async def test_voice_tts_failure_hides_exception(mock_getenv, mock_post, report, ai_cog, mock_ctx):
+    import requests
+
+    expected = "Something broke generating speech. Check the bot logs and try again."
+    ai_cog.grok.send_message.return_value = ("tts-id", "spoken text")
+    mock_post.side_effect = requests.exceptions.RequestException("connection reset")
+
+    await ai_cog.voice.callback(ai_cog, mock_ctx, text="say hello")
+
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("error message", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.send.assert_awaited_once_with(expected)
+    assert "connection reset" not in actual

--- a/tests/test_call_grok_imagine.py
+++ b/tests/test_call_grok_imagine.py
@@ -59,3 +59,18 @@ def test_call_grok_imagine_multiple_images_uses_image_urls(mock_client_cls, repo
     assert kwargs["image_urls"] == urls
     assert "image_url" not in kwargs
     assert result["status"] == "success"
+
+
+@patch("chatgpt_functions.logger")
+@patch("chatgpt_functions.Client")
+def test_call_grok_imagine_logs_exceptions(mock_client_cls, mock_logger, report):
+    mock_client = MagicMock()
+    mock_client_cls.return_value = mock_client
+    mock_client.image.sample.side_effect = RuntimeError("api down")
+
+    result = call_grok_imagine("a cat")
+
+    report.record("status", "error", result["status"], section=SECTION_COMMANDS)
+    report.record("error", "api down", result["error"], section=SECTION_COMMANDS)
+    assert result == {"status": "error", "error": "api down"}
+    mock_logger.exception.assert_called_once_with("Grok Imagine failed")

--- a/tests/test_first_commands.py
+++ b/tests/test_first_commands.py
@@ -138,17 +138,93 @@ async def test_juice(report, mock_db_ops, mock_bot, mock_ctx, leaderboard_first_
     assert embed.title == "Juice Board 🧃"
 
 
+@patch("cogs.first.asyncio.sleep", new_callable=AsyncMock)
+@patch("cogs.first.datetime")
+async def test_first_empty_table_allows_claim(
+    mock_datetime, _mock_sleep, report, mock_db_ops, mock_bot, mock_ctx, empty_first_df,
+):
+    expected = f"{mock_ctx.author.mention} is first today! 🥳 +1 **DINK**"
+    est = pytz.timezone("US/Eastern")
+    today = est.localize(datetime(2024, 6, 11, 8, 0, 0))
+
+    mock_datetime.utcnow.return_value = today.astimezone(pytz.UTC).replace(tzinfo=None)
+    mock_db_ops.get_table_data.return_value = empty_first_df
+
+    cog = First(mock_bot)
+    await cog.first.callback(cog, mock_ctx)
+
+    actual = mock_ctx.channel.send.call_args.args[0]
+    report.record("channel.send", expected, actual, section=SECTION_COMMANDS)
+    report.record("db write", mock_ctx.author.id, mock_db_ops.write_first_entry.call_args.args[0], section=SECTION_COMMANDS)
+
+    mock_db_ops.write_first_entry.assert_called_once_with(mock_ctx.author.id)
+    mock_db_ops.record_dink_mint.assert_called_once_with(mock_ctx.author.id, 1.0)
+    mock_ctx.channel.send.assert_awaited_once_with(expected)
+
+
+async def test_score_empty(report, mock_db_ops, mock_bot, mock_ctx, empty_first_df):
+    expected = "No firsts recorded yet — claim one with `_1st`!"
+    mock_db_ops.get_table_data.return_value = empty_first_df
+    cog = First(mock_bot)
+
+    await cog.score.callback(cog, mock_ctx)
+
+    actual = mock_ctx.channel.send.call_args.args[0]
+    report.record("channel.send", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.channel.send.assert_awaited_once_with(expected)
+
+
+async def test_score_fewer_than_five_winners(report, mock_db_ops, mock_bot, mock_ctx, sample_first_df):
+    mock_db_ops.get_table_data.return_value = sample_first_df
+    cog = First(mock_bot)
+
+    await cog.score.callback(cog, mock_ctx)
+
+    embed = mock_ctx.channel.send.call_args.kwargs["embed"]
+    # sample_first_df has 2 distinct users
+    report.record("embed field count", 2, len(embed.fields), section=SECTION_COMMANDS)
+    mock_ctx.channel.send.assert_awaited_once()
+    assert embed.title == "First Leaderboard"
+    assert len(embed.fields) == 2
+
+
+async def test_juice_empty(report, mock_db_ops, mock_bot, mock_ctx, empty_first_df):
+    expected = "No firsts recorded yet — claim one with `_1st`!"
+    mock_db_ops.get_table_data.return_value = empty_first_df
+    cog = First(mock_bot)
+
+    await cog.juice.callback(cog, mock_ctx)
+
+    actual = mock_ctx.channel.send.call_args.args[0]
+    report.record("channel.send", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.channel.send.assert_awaited_once_with(expected)
+
+
+async def test_juice_fewer_than_five_winners(report, mock_db_ops, mock_bot, mock_ctx, sample_first_df):
+    mock_db_ops.get_table_data.return_value = sample_first_df
+    cog = First(mock_bot)
+
+    await cog.juice.callback(cog, mock_ctx)
+
+    embed = mock_ctx.channel.send.call_args.kwargs["embed"]
+    report.record("embed field count", 2, len(embed.fields), section=SECTION_COMMANDS)
+    mock_ctx.channel.send.assert_awaited_once()
+    assert embed.title == "Juice Board 🧃"
+    assert len(embed.fields) == 2
+
+
 async def test_graph_empty(report, mock_db_ops, mock_bot, mock_ctx, empty_first_df):
+    expected = "No firsts recorded yet — claim one with `_1st`!"
     mock_db_ops.get_table_data.return_value = empty_first_df
     cog = First(mock_bot)
 
     await cog.graph.callback(cog, mock_ctx)
 
     message = mock_ctx.send.call_args.args[0]
-    report.record("message", "contains 'No firsts recorded yet'", message, section=SECTION_COMMANDS)
+    report.record("message", expected, message, section=SECTION_COMMANDS)
 
-    mock_ctx.send.assert_awaited_once()
-    assert "No firsts recorded yet" in message
+    mock_ctx.send.assert_awaited_once_with(expected)
+    assert message == expected
 
 
 async def test_graph_with_data(report, mock_db_ops, mock_bot, mock_ctx, sample_first_df):

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -20,5 +20,9 @@ MAX_GROK_SESSION_TURNS = 20
 # Grok Imagine multi-reference edit limit (xAI API: up to 3 source images).
 MAX_IMAGINE_INPUT_IMAGES = 3
 
+# Per-user _imagine rate limit (discord.py cooldown: rate uses per period seconds).
+IMAGINE_RATE_LIMIT = 30
+IMAGINE_RATE_PERIOD_SECONDS = 3600
+
 # DINK awarded for each successful _1st claim (MySQL ledger only)
 DINK_MINT_AMOUNT = float(os.getenv("DINK_MINT_AMOUNT", "1"))


### PR DESCRIPTION
## Summary
- Guard empty/small `firstlist_id` data in `_1st`, `_score`, and `_juice`, and fix the `_graph` empty-state prefix typo
- Keep Discord error replies user-friendly while logging full details to the console; rate-limit `_imagine` to 30/user/hour
- Rewrite command help/briefs to be short and member-facing (no DB/provider jargon)

## Test plan
- [ ] Run `./scripts/test.sh -m "not live"` (or at least first/AI command tests)
- [ ] Confirm `_score` / `_juice` work with fewer than 5 winners
- [ ] Confirm `_help` shows concise briefs for AI and first-game commands
- [ ] Confirm hitting `_imagine` 31 times in an hour returns the cooldown message without stack traces