### PR TITLE
Add Eastern date to Grok system prompt with daily chat clear

### DIFF
--- a/cogs/ai.py
+++ b/cogs/ai.py
@@ -1,4 +1,4 @@
-from discord.ext import commands
+from discord.ext import commands, tasks
 from chatgpt_functions import GrokClient, call_grok_imagine, GROK_IMAGINE_FILENAME
 from utils.constants import (
     EMBED_COLOR,
@@ -8,13 +8,19 @@ from utils.constants import (
     MAX_IMAGINE_INPUT_IMAGES,
 )
 from utils.db import db_ops
+from datetime import datetime, timedelta
+import asyncio
 import discord
+import pytz
 import requests
 import os
 import io
 import logging
 
 logger = logging.getLogger(__name__)
+
+EASTERN = pytz.timezone("US/Eastern")
+DAILY_CLEAR_HOUR = 3  # 3am US/Eastern
 
 
 class AI(commands.Cog):
@@ -38,13 +44,54 @@ class AI(commands.Cog):
             "(list_bot_commands), and live data (get_first_game_stats, get_juice_stats, get_dink_ledger). "
             "Whenever someone asks about you, your commands, your capabilities, the first game, juice, streaks, "
             "DINK, or how any of your features work, call those tools and answer from their output instead of guessing. "
-            "For juice: higher is better — it is minutes past midnight Eastern when someone claims _1st, and the "
-            "goal is to wait as late as possible to maximize juice. Use get_juice_stats for who has the most juice. "
             "You also have real-time web and X search; use them to confirm facts and fetch primary sources for current events. "
             "In your final answer, write economically. A single sentence should often be enough. "
             "Every sentence or phrase should be essential, such that removing it would make the final response incomplete or substantially worse. "
             "Do not use markdown bold (**text**) for whole responses or multiple sentences—especially after web search. "
         )
+
+    async def cog_load(self):
+        self.daily_chat_clear.start()
+
+    def cog_unload(self):
+        self.daily_chat_clear.cancel()
+
+    def _reset_session(self):
+        self.last_response_id = None
+        self._session_turns = 0
+
+    def _build_system_prompt(self) -> str:
+        """Base prompt plus today's US/Eastern date (no clock time)."""
+        today = datetime.now(EASTERN).strftime("%A, %B %d, %Y")
+        return (
+            f"{self.system_prompt}"
+            f"Today's date is {today} (US/Eastern). "
+            "Use this for any date-sensitive answers."
+        )
+
+    def _clear_session_if_new_day(self) -> bool:
+        """Clear the shared chat at the configured daily hour (US/Eastern). Returns True if cleared."""
+        now = datetime.now(EASTERN)
+        if now.hour == DAILY_CLEAR_HOUR:
+            self._reset_session()
+            logger.info(
+                "Auto-cleared shared Grok chat at %sam US/Eastern",
+                DAILY_CLEAR_HOUR,
+            )
+            return True
+        return False
+
+    @tasks.loop(hours=1)
+    async def daily_chat_clear(self):
+        """Clear the shared chat daily so the next session gets a fresh Eastern date."""
+        self._clear_session_if_new_day()
+
+    @daily_chat_clear.before_loop
+    async def before_daily_chat_clear(self):
+        await self.bot.wait_until_ready()
+        now = datetime.now(EASTERN)
+        next_hour = now.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+        await asyncio.sleep((next_hour - now).total_seconds())
 
     @commands.command(brief="Ask a question")
     async def ask(self, ctx, *, arg):
@@ -59,14 +106,13 @@ class AI(commands.Cog):
         async with ctx.typing():
             # Start a new session if we've hit the turn limit (keeps context/cost bounded)
             if self._session_turns >= MAX_GROK_SESSION_TURNS:
-                self.last_response_id = None
-                self._session_turns = 0
+                self._reset_session()
 
             try:
                 next_response_id, response_text = self.grok.send_message(
                     arg,
                     previous_response_id=self.last_response_id,
-                    system_prompt=self.system_prompt,
+                    system_prompt=self._build_system_prompt(),
                     user_id=ctx.author.id,
                     message_id=ctx.message.id,
                     image_urls=image_urls if image_urls else None,
@@ -141,8 +187,7 @@ class AI(commands.Cog):
     async def clear(self, ctx):
         """Clear the shared chat so the next _ask starts fresh."""
 
-        self.last_response_id = None
-        self._session_turns = 0
+        self._reset_session()
         await ctx.send("Chat history cleared! Starting fresh, dude! 🤙")
 
     @commands.command(brief="Answer a prompt out loud")
@@ -165,13 +210,12 @@ class AI(commands.Cog):
         async with ctx.typing():
             try:
                 if self._session_turns >= MAX_GROK_SESSION_TURNS:
-                    self.last_response_id = None
-                    self._session_turns = 0
+                    self._reset_session()
 
                 next_response_id, response_text = self.grok.send_message(
                     text,
                     previous_response_id=self.last_response_id,
-                    system_prompt=self.system_prompt,
+                    system_prompt=self._build_system_prompt(),
                     user_id=ctx.author.id,
                     message_id=ctx.message.id,
                 )

--- a/tests/test_self_knowledge.py
+++ b/tests/test_self_knowledge.py
@@ -125,6 +125,62 @@ def test_ai_system_prompt_uses_self_knowledge_tools(report, mock_bot):
     assert_eq(report, SECTION_SELF_KNOWLEDGE, "AI prompt tools", "juice + dink", "juice + dink")
 
 
+def test_ai_system_prompt_includes_eastern_date(report, mock_bot):
+    from cogs.ai import AI, EASTERN
+    from datetime import datetime
+
+    with patch("cogs.ai.GrokClient"):
+        cog = AI(mock_bot)
+
+    prompt = cog._build_system_prompt()
+    today = datetime.now(EASTERN).strftime("%B %d, %Y")
+    assert "US/Eastern" in prompt
+    assert today in prompt
+    date_clause = prompt.split("Today's date is", 1)[1]
+    assert ":" not in date_clause  # date only, no clock time
+    assert_eq(report, SECTION_SELF_KNOWLEDGE, "AI prompt date", today, today)
+
+
+def test_daily_chat_clear_resets_session_at_clear_hour(report, mock_bot):
+    from cogs.ai import AI, DAILY_CLEAR_HOUR, EASTERN
+    from datetime import datetime
+
+    with patch("cogs.ai.GrokClient"):
+        cog = AI(mock_bot)
+
+    cog.last_response_id = "stale-id"
+    cog._session_turns = 7
+    clear_time = EASTERN.localize(datetime(2026, 7, 10, DAILY_CLEAR_HOUR, 0, 0))
+    with patch("cogs.ai.datetime") as mock_dt:
+        mock_dt.now.return_value = clear_time
+        cleared = cog._clear_session_if_new_day()
+
+    assert cleared is True
+    assert cog.last_response_id is None
+    assert cog._session_turns == 0
+    assert_eq(report, SECTION_SELF_KNOWLEDGE, "daily clear", "reset", "reset")
+
+
+def test_daily_chat_clear_skips_other_hours(report, mock_bot):
+    from cogs.ai import AI, EASTERN
+    from datetime import datetime
+
+    with patch("cogs.ai.GrokClient"):
+        cog = AI(mock_bot)
+
+    cog.last_response_id = "keep-me"
+    cog._session_turns = 3
+    noon = EASTERN.localize(datetime(2026, 7, 10, 12, 0, 0))
+    with patch("cogs.ai.datetime") as mock_dt:
+        mock_dt.now.return_value = noon
+        cleared = cog._clear_session_if_new_day()
+
+    assert cleared is False
+    assert cog.last_response_id == "keep-me"
+    assert cog._session_turns == 3
+    assert_eq(report, SECTION_SELF_KNOWLEDGE, "non-clear-hour", "kept", "kept")
+
+
 def _make_tool_call(name: str, arguments: dict, call_id: str = "call-1"):
     tool_call = MagicMock()
     tool_call.id = call_id


### PR DESCRIPTION
## Summary
- Inject today's US/Eastern date (no clock time) into the Grok system prompt when a new `_ask` / `_voice` session starts
- Auto-clear the shared chat daily at a configurable Eastern hour (`DAILY_CLEAR_HOUR`, currently 3am) so the next session picks up a fresh date
- Drop redundant juice guidance from the system prompt (covered by self-knowledge docs/tools)
- Add coverage for the date prompt and daily clear / non-clear-hour behavior

## Test plan
- [ ] Run `pytest tests/test_self_knowledge.py tests/test_ai_commands.py`
- [ ] Start a fresh `_ask` and confirm the bot knows today's Eastern date
- [ ] Confirm `_clear` still resets the shared session manually
- [ ] After deploy, verify logs show the daily auto-clear (or temporarily change `DAILY_CLEAR_HOUR` in a test env)