### PR TITLE
Add Discord slash commands (hybrid migration)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,9 @@ SQL_PASSWORD=
 SQL_DATABASE=
 XAI_API_KEY=
 
-# Optional: DINK awarded per successful _1st claim (default 1)
+# Optional: guild ID for instant slash-command sync on startup.
+# Without this, commands sync globally (can take up to ~1 hour to appear).
+# DISCORD_GUILD_ID=
+
+# Optional: DINK awarded per successful /1st claim (default 1)
 DINK_MINT_AMOUNT=1

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ ChatGPT intelligently recognizes when to invoke this function and uses the infor
 
 #### Self-Knowledge Tools
 
-The Grok integration (`_ask` / `_voice`) is self-aware: alongside xAI's server-side web/X search, every request exposes client-side tools that let Grok look up how the bot itself works instead of guessing:
+The Grok integration (`/ask` / `/voice`) is self-aware: alongside xAI's server-side web/X search, every request exposes client-side tools that let Grok look up how the bot itself works instead of guessing:
 
 | Tool | What it returns |
 |------|-----------------|
-| `get_bot_documentation` | Curated member-facing docs (`docs/self_knowledge/`) on the bot overview, the `_1st` game, DinkCoin, AI features, and server stats |
+| `get_bot_documentation` | Curated member-facing docs (`docs/self_knowledge/`) on the bot overview, the `/1st` game, DinkCoin, AI features, and server stats |
 | `list_bot_commands` | The live command list, generated from the registered cogs at runtime |
 | `get_first_game_stats` | Live first-win leaderboard, most recent winner, and current streak |
 | `get_juice_stats` | Live juice leaderboard (total juice), single-day high score |
@@ -76,13 +76,13 @@ The core Discord functionality of this project is contained in the `bot.py` file
 
 ### DinkCoin
 
-Successful `_1st` claims award **1 DINK** (configurable via `DINK_MINT_AMOUNT`). Balances, the server ledger, and peer-to-peer trades all live in MySQL — no blockchain or crypto wallet required.
+Successful `/1st` claims award **1 DINK** (configurable via `DINK_MINT_AMOUNT`). Balances, the server ledger, and peer-to-peer trades all live in MySQL — no blockchain or crypto wallet required.
 
 | Command | Description |
 |---------|-------------|
-| `_balance` | Show your DINK balance |
-| `_ledger` | Top holders leaderboard |
-| `_pay @user <amount>` | Send DINK to another user |
+| `/balance` | Show your DINK balance |
+| `/ledger` | Top holders leaderboard |
+| `/pay` | Send DINK to another user |
 
 Setup: run `scripts/dinkcoin_schema.sql` against your MySQL database once.
 
@@ -111,7 +111,9 @@ Setup: run `scripts/dinkcoin_schema.sql` against your MySQL database once.
 
 1. Clone the repository.
 2. Copy `.env.example` to `.env` and fill in values from your hosting dashboard.
-3. Run locally: `./scripts/dev.sh`
+3. Invite (or re-invite) the bot with OAuth2 scopes **`bot`** and **`applications.commands`**. Without `applications.commands`, slash commands will not appear in the server.
+4. Optionally set `DISCORD_GUILD_ID` for instant slash-command sync on startup (otherwise Discord may take up to ~1 hour for global sync).
+5. Run locally: `./scripts/dev.sh`
 
 The dev script creates a virtual environment, installs dependencies, and starts the bot.
 
@@ -122,7 +124,7 @@ Local runs use the same credentials as production (Discord token, MySQL, xAI). O
 1. Stop the bot on your hosting site.
 2. Ensure `.env` is populated (see `.env.example`).
 3. Run `./scripts/dev.sh`
-4. Test commands on your Discord server (prefix is `_`).
+4. Test commands on your Discord server (type `/` for slash commands; `_` prefix still works).
 5. Press Ctrl+C to stop, then restart the hosted bot.
 
 ## Testing

--- a/bot.py
+++ b/bot.py
@@ -21,6 +21,9 @@ logging.basicConfig(
     force=True,
 )
 
+logger = logging.getLogger(__name__)
+
+
 # Setup bot
 class DinkBot(commands.Bot):
     """A Discord bot with first-tracking, AI capabilities, and utility functions."""
@@ -37,7 +40,20 @@ class DinkBot(commands.Bot):
         await self.load_extension('cogs.utility')
         await self.load_extension('cogs.misc')
 
+        await self._sync_app_commands()
         self.loop.create_task(self._console_post_loop())
+
+    async def _sync_app_commands(self):
+        """Register slash commands with Discord (guild sync when DISCORD_GUILD_ID is set)."""
+        guild_id = os.getenv("DISCORD_GUILD_ID")
+        if guild_id:
+            guild = discord.Object(id=int(guild_id))
+            self.tree.copy_global_to(guild=guild)
+            synced = await self.tree.sync(guild=guild)
+            logger.info("Synced %s app commands to guild %s", len(synced), guild_id)
+        else:
+            synced = await self.tree.sync()
+            logger.info("Synced %s app commands globally", len(synced))
 
     async def _console_post_loop(self):
         await self.wait_until_ready()
@@ -60,11 +76,10 @@ class DinkBot(commands.Bot):
         if isinstance(error, commands.CommandOnCooldown):
             minutes = max(1, math.ceil(error.retry_after / 60))
             await ctx.send(
-                f"You've hit the `_imagine` limit (30 per hour). "
+                f"You've hit the `/imagine` limit (30 per hour). "
                 f"Try again in about {minutes} minute{'s' if minutes != 1 else ''}."
             )
             return
-        logger = logging.getLogger(__name__)
         logger.exception("Command error in %s: %s", getattr(ctx.command, "name", "?"), error)
         await ctx.send("Something went wrong running that command.")
 

--- a/cogs/ai.py
+++ b/cogs/ai.py
@@ -1,4 +1,5 @@
 from discord.ext import commands, tasks
+from discord import app_commands
 from chatgpt_functions import GrokClient, call_grok_imagine, GROK_IMAGINE_FILENAME
 from utils.constants import (
     EMBED_COLOR,
@@ -8,7 +9,9 @@ from utils.constants import (
     MAX_IMAGINE_INPUT_IMAGES,
 )
 from utils.db import db_ops
+from utils.interactions import acknowledge
 from datetime import datetime, timedelta
+from typing import List, Optional
 import asyncio
 import discord
 import pytz
@@ -23,6 +26,26 @@ EASTERN = pytz.timezone("US/Eastern")
 DAILY_CLEAR_HOUR = 3  # 3am US/Eastern
 
 
+def _image_urls_from_message(ctx) -> List[str]:
+    return [
+        a.url
+        for a in ctx.message.attachments
+        if a.content_type and a.content_type.startswith("image/")
+    ]
+
+
+def _collect_image_urls(ctx, *attachments: Optional[discord.Attachment]) -> List[str]:
+    """Prefer explicit slash attachment options; fall back to message attachments."""
+    urls = [
+        a.url
+        for a in attachments
+        if a is not None and a.content_type and a.content_type.startswith("image/")
+    ]
+    if urls:
+        return urls
+    return _image_urls_from_message(ctx)
+
+
 class AI(commands.Cog):
     """Chat, image generation, and voice."""
 
@@ -34,8 +57,8 @@ class AI(commands.Cog):
         self._session_turns = 0  # turns in current session; reset when starting fresh or hitting limit
         self.system_prompt = (
             "You are Peter Dinklage, the resident bot of this Discord server (Dinkscord). "
-            "You are not just a chat assistant: you run the daily _1st game, the DinkCoin (DINK) economy, "
-            "image generation, and server stats. Commands use the '_' prefix. "
+            "You are not just a chat assistant: you run the daily /1st game, the DinkCoin (DINK) economy, "
+            "image generation, and server stats. Commands are slash commands (also available with the '_' prefix). "
             "You speak to server members as yourself — never as a separate AI product. "
             "Never mention API providers, model names, databases, table names, code files, "
             "environment variables, or other internal implementation details. "
@@ -93,24 +116,24 @@ class AI(commands.Cog):
         next_hour = now.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
         await asyncio.sleep((next_hour - now).total_seconds())
 
-    @commands.command(brief="Ask a question")
-    async def ask(self, ctx, *, arg):
+    @commands.hybrid_command(brief="Ask a question")
+    @app_commands.describe(
+        prompt="Your question or message",
+        image="Optional image to include with your question",
+    )
+    async def ask(self, ctx, image: discord.Attachment = None, *, prompt: str):
         """Ask a question. You can also attach images."""
 
-        image_urls = [
-            a.url
-            for a in ctx.message.attachments
-            if a.content_type and a.content_type.startswith("image/")
-        ]
+        image_urls = _collect_image_urls(ctx, image)
 
-        async with ctx.typing():
+        async with acknowledge(ctx):
             # Start a new session if we've hit the turn limit (keeps context/cost bounded)
             if self._session_turns >= MAX_GROK_SESSION_TURNS:
                 self._reset_session()
 
             try:
                 next_response_id, response_text = self.grok.send_message(
-                    arg,
+                    prompt,
                     previous_response_id=self.last_response_id,
                     system_prompt=self._build_system_prompt(),
                     user_id=ctx.author.id,
@@ -118,7 +141,7 @@ class AI(commands.Cog):
                     image_urls=image_urls if image_urls else None,
                 )
             except Exception:
-                logger.exception("_ask failed for user %s", ctx.author.id)
+                logger.exception("/ask failed for user %s", ctx.author.id)
                 await ctx.send("Something broke on my end, dude. Check the bot logs and try again.")
                 return
 
@@ -128,31 +151,41 @@ class AI(commands.Cog):
 
             await ctx.send(response_text or "Sorry, I couldn't generate a reply this time. Please try again.")
 
-    @commands.command(brief="Generate an AI image")
+    @commands.hybrid_command(brief="Generate an AI image")
     @commands.cooldown(IMAGINE_RATE_LIMIT, IMAGINE_RATE_PERIOD_SECONDS, commands.BucketType.user)
-    async def imagine(self, ctx, *, arg):
+    @app_commands.describe(
+        prompt="Describe the image to generate or edit",
+        image1="Optional first reference image",
+        image2="Optional second reference image",
+        image3="Optional third reference image",
+    )
+    async def imagine(
+        self,
+        ctx,
+        image1: discord.Attachment = None,
+        image2: discord.Attachment = None,
+        image3: discord.Attachment = None,
+        *,
+        prompt: str,
+    ):
         """Generate an AI image based on a prompt and optional input images.
 
         Attach up to 3 images to edit or combine them; refer to them in the prompt
         as <IMAGE_0>, <IMAGE_1>, <IMAGE_2> (attachment order).
         """
 
-        db_ops.write_dalle_entry(user_id=ctx.author.id, prompt=arg, message_id=ctx.message.id)
+        db_ops.write_dalle_entry(user_id=ctx.author.id, prompt=prompt, message_id=ctx.message.id)
 
-        input_image_urls = [
-            a.url
-            for a in ctx.message.attachments
-            if a.content_type and a.content_type.startswith("image/")
-        ]
+        input_image_urls = _collect_image_urls(ctx, image1, image2, image3)
         if len(input_image_urls) > MAX_IMAGINE_INPUT_IMAGES:
             await ctx.send(
-                f"You can attach at most {MAX_IMAGINE_INPUT_IMAGES} images for `_imagine`."
+                f"You can attach at most {MAX_IMAGINE_INPUT_IMAGES} images for `/imagine`."
             )
             return
 
-        async with ctx.typing():
+        async with acknowledge(ctx):
             response = call_grok_imagine(
-                arg,
+                prompt,
                 input_image_urls=input_image_urls or None,
             )
 
@@ -163,7 +196,7 @@ class AI(commands.Cog):
                 )
                 embed = discord.Embed(title="🎨 AI Generated Image", color=EMBED_COLOR)
                 embed.set_image(url=f"attachment://{GROK_IMAGINE_FILENAME}")
-                embed.add_field(name="Prompt", value=arg, inline=False)
+                embed.add_field(name="Prompt", value=prompt, inline=False)
                 if input_image_urls:
                     count = len(input_image_urls)
                     embed.add_field(
@@ -174,7 +207,7 @@ class AI(commands.Cog):
                 embed.set_footer(text=f"Requested by {ctx.author.display_name}")
                 await ctx.send(embed=embed, file=image_file)
             else:
-                logger.error("_imagine failed: %s", response.get("error"))
+                logger.error("/imagine failed: %s", response.get("error"))
                 await ctx.send(
                     embed=discord.Embed(
                         title="❌ Error",
@@ -183,22 +216,23 @@ class AI(commands.Cog):
                     )
                 )
 
-    @commands.command(brief="Clear the shared chat")
+    @commands.hybrid_command(brief="Clear the shared chat")
     async def clear(self, ctx):
-        """Clear the shared chat so the next _ask starts fresh."""
+        """Clear the shared chat so the next /ask starts fresh."""
 
         self._reset_session()
         await ctx.send("Chat history cleared! Starting fresh, dude! 🤙")
 
-    @commands.command(brief="Answer a prompt out loud")
-    async def voice(self, ctx, *, text):
+    @commands.hybrid_command(brief="Answer a prompt out loud")
+    @app_commands.describe(prompt="The prompt to answer and speak aloud")
+    async def voice(self, ctx, *, prompt: str):
         """Answer a prompt and read the reply aloud."""
 
-        if not text:
+        if not prompt:
             await ctx.send("Please provide text to convert to speech.")
             return
 
-        if len(text) > 15000:
+        if len(prompt) > 15000:
             await ctx.send("Text is too long. Maximum 15,000 characters.")
             return
 
@@ -207,13 +241,13 @@ class AI(commands.Cog):
             await ctx.send("XAI API key not configured.")
             return
 
-        async with ctx.typing():
+        async with acknowledge(ctx):
             try:
                 if self._session_turns >= MAX_GROK_SESSION_TURNS:
                     self._reset_session()
 
                 next_response_id, response_text = self.grok.send_message(
-                    text,
+                    prompt,
                     previous_response_id=self.last_response_id,
                     system_prompt=self._build_system_prompt(),
                     user_id=ctx.author.id,
@@ -250,10 +284,10 @@ class AI(commands.Cog):
                 await ctx.send(file=audio_file)
 
             except requests.exceptions.RequestException:
-                logger.exception("_voice TTS request failed for user %s", ctx.author.id)
+                logger.exception("/voice TTS request failed for user %s", ctx.author.id)
                 await ctx.send("Something broke generating speech. Check the bot logs and try again.")
             except Exception:
-                logger.exception("_voice failed for user %s", ctx.author.id)
+                logger.exception("/voice failed for user %s", ctx.author.id)
                 await ctx.send("Something broke on my end, dude. Check the bot logs and try again.")
 
 

--- a/cogs/dinkcoin.py
+++ b/cogs/dinkcoin.py
@@ -1,6 +1,7 @@
 import logging
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from utils.constants import EMBED_COLOR
@@ -15,13 +16,14 @@ class DinkCoin(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(brief="Check your DINK balance")
+    @commands.hybrid_command(brief="Check your DINK balance")
     async def balance(self, ctx):
         """Show your DINK balance."""
         balance = db_ops.get_dink_balance(ctx.author.id)
         await ctx.send(f"{ctx.author.mention} has **{balance:g} DINK**")
 
-    @commands.command(brief="Show the DINK leaderboard")
+    @commands.hybrid_command(brief="Show the DINK leaderboard")
+    @app_commands.describe(limit="How many holders to show (1–20, default 10)")
     async def ledger(self, ctx, limit: int = 10):
         """Show the DINK leaderboard."""
         limit = min(max(limit, 1), 20)
@@ -37,7 +39,7 @@ class DinkCoin(commands.Cog):
         if df.empty:
             embed.add_field(
                 name="No balances yet",
-                value="Claim `_1st` to earn your first DINK!",
+                value="Claim `/1st` to earn your first DINK!",
                 inline=False,
             )
         else:
@@ -53,9 +55,13 @@ class DinkCoin(commands.Cog):
 
         await ctx.send(embed=embed)
 
-    @commands.command(brief="Send DINK to another user")
+    @commands.hybrid_command(brief="Send DINK to another user")
+    @app_commands.describe(
+        member="Who to send DINK to",
+        amount="Whole number of DINK to send",
+    )
     async def pay(self, ctx, member: discord.Member, amount: float):
-        """Send DINK to another user. Usage: `_pay @user <amount>`"""
+        """Send DINK to another user."""
         if member.bot:
             await ctx.send("You cannot pay bots.")
             return

--- a/cogs/first.py
+++ b/cogs/first.py
@@ -1,4 +1,5 @@
 import discord
+from discord import app_commands
 from discord.ext import commands
 import asyncio
 import io
@@ -9,6 +10,7 @@ from datetime import datetime
 import pytz
 from utils.db import db_ops, streak_calc, juice_calc
 from utils.constants import GENERAL_CHANNEL_ID, EMBED_COLOR, DINK_MINT_AMOUNT
+from utils.interactions import acknowledge
 
 logger = logging.getLogger(__name__)
 
@@ -18,14 +20,14 @@ class First(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(name='1st', brief='Claim first for today')
+    @commands.hybrid_command(name='1st', brief='Claim first for today')
     async def first(self, ctx):
         """Claim first for today. Only works in #general, once per day."""
         # Checks if first has been claimed, if not, writes user_id and timestamp to SQL database
         channel_id = GENERAL_CHANNEL_ID    # dinkscord general text-channel id
         if ctx.channel.id != channel_id:
             msg = f'Please send your message to <#{channel_id}>.'
-            await ctx.channel.send(msg)
+            await ctx.send(msg)
         else:
             utc_now = datetime.utcnow()
             utc_now = pytz.timezone('UTC').localize(utc_now).astimezone(pytz.timezone('US/Eastern'))
@@ -40,22 +42,22 @@ class First(commands.Cog):
             if already_claimed:
                 Author = ctx.author.mention
                 msg = f'Sorry {Author}, first has already been claimed today. 😭'
-                await ctx.channel.send(msg)
+                await ctx.send(msg)
             else:
                 db_ops.write_first_entry(ctx.author.id)
                 db_ops.record_dink_mint(ctx.author.id, DINK_MINT_AMOUNT)
                 await asyncio.sleep(0.5)
                 Author = ctx.author.mention
                 msg = f"{Author} is first today! 🥳 +{DINK_MINT_AMOUNT:g} **DINK**"
-                await ctx.channel.send(msg)
+                await ctx.send(msg)
 
-    @commands.command(brief='Show the firsts leaderboard')
+    @commands.hybrid_command(brief='Show the firsts leaderboard')
     async def score(self, ctx):
         """Show the firsts leaderboard and current streak."""
         # reads SQL database and generates an embed with list of names and scores
         df = db_ops.get_table_data('firstlist_id')
         if df.empty:
-            await ctx.channel.send("No firsts recorded yet — claim one with `_1st`!")
+            await ctx.send("No firsts recorded yet — claim one with `/1st`!")
             return
 
         streak = streak_calc.calculate_streak(df)
@@ -67,25 +69,28 @@ class First(commands.Cog):
                             inline=False)
         txt = f'Most recent: {self.bot.get_user(int(df.user_id.iloc[-1]))} 🔥 {streak} days'
         embed.set_footer(text=txt)
-        await ctx.channel.send(embed=embed)
+        await ctx.send(embed=embed)
 
-    @commands.command(brief='Show firsts stats for a user')
-    async def stats(self, ctx, *, args=None):
-        """Show score, juice, and streak for you or a mentioned user."""
+    @commands.hybrid_command(brief='Show firsts stats for a user')
+    @app_commands.describe(member='User to look up (defaults to you)')
+    async def stats(self, ctx, member: discord.Member = None):
+        """Show score, juice, and streak for you or another user."""
         # reads SQL database and generates an embed with list of names and scores
         df = db_ops.get_table_data('firstlist_id')
 
-        if len(ctx.message.mentions) > 0:
+        if member is not None:
+            author_id = str(member.id)
+        elif ctx.message.mentions:
             author_id = str(ctx.message.mentions[0].id)
         else:
-            author_id = str(ctx.message.author.id)
+            author_id = str(ctx.author.id)
 
         try:
             author = self.bot.get_user(int(author_id))
             # Check if user has any entries
             user_entries = df[df.user_id == author_id]
             if user_entries.empty:
-                await ctx.channel.send('This user has never gotten a first!')
+                await ctx.send('This user has never gotten a first!')
                 return
 
             streak = streak_calc.calculate_user_streak(df, author_id)
@@ -98,116 +103,118 @@ class First(commands.Cog):
             embed.add_field(name="Juice", value=f'{int(juice)} 🧃', inline=True)
             embed.add_field(name="Longest streak", value=f'{streak} days 🔥', inline=True)
 
-            await ctx.channel.send(embed=embed)
+            await ctx.send(embed=embed)
         except ValueError:
             logger.exception("Invalid user ID in stats command: %s", author_id)
-            await ctx.channel.send('Error: Invalid user ID format.')
+            await ctx.send('Error: Invalid user ID format.')
         except Exception:
             logger.exception("Unexpected error in stats command for user %s", author_id)
-            await ctx.channel.send('An unexpected error occurred while fetching stats.')
+            await ctx.send('An unexpected error occurred while fetching stats.')
 
-    @commands.command(brief='Show the juice leaderboard')
+    @commands.hybrid_command(brief='Show the juice leaderboard')
     async def juice(self, ctx):
         """Show the juice leaderboard and one-day high score."""
         df = db_ops.get_table_data('firstlist_id')
         if df.empty:
-            await ctx.channel.send("No firsts recorded yet — claim one with `_1st`!")
+            await ctx.send("No firsts recorded yet — claim one with `/1st`!")
             return
 
         juice_df, highscore_user_id, highscore_value = juice_calc.calculate_juice(df)
         
-        embed=discord.Embed(title='Juice Board 🧃',description='Total minutes between _1st and midnight 🧃',color=EMBED_COLOR)
+        embed=discord.Embed(title='Juice Board 🧃',description='Total minutes between /1st and midnight 🧃',color=EMBED_COLOR)
         for i in range(min(5, len(juice_df))):
             embed.add_field(name=self.bot.get_user(int(juice_df.iloc[i]['user_id'])),
                           value=int(juice_df.iloc[i]['juice']),
                           inline=False)
         txt = f'1-Day Highscore: {self.bot.get_user(int(highscore_user_id))}🧃{int(highscore_value)} mins'
         embed.set_footer(text=txt)
-        await ctx.channel.send(embed=embed)
+        await ctx.send(embed=embed)
 
-    @commands.command(brief='Graph firsts over time')
+    @commands.hybrid_command(brief='Graph firsts over time')
     async def graph(self, ctx):
         """Graph firsts over time."""
-        df_first = db_ops.get_table_data('firstlist_id')
-        if df_first.empty:
-            await ctx.send("No firsts recorded yet — claim one with `_1st`!")
-            return
+        async with acknowledge(ctx):
+            df_first = db_ops.get_table_data('firstlist_id')
+            if df_first.empty:
+                await ctx.send("No firsts recorded yet — claim one with `/1st`!")
+                return
 
-        df_first['_1st to date'] = df_first.groupby('user_id').cumcount() + 1
-        bg, grid, text = '#2b2d31', '#404249', '#dcddde'
-        plt.rcParams.update({
-            'figure.facecolor': bg, 'axes.facecolor': bg, 'axes.edgecolor': grid,
-            'axes.labelcolor': text, 'text.color': text, 'xtick.color': text,
-            'ytick.color': text, 'grid.color': grid, 'grid.alpha': 0.45,
-        })
+            df_first['_1st to date'] = df_first.groupby('user_id').cumcount() + 1
+            bg, grid, text = '#2b2d31', '#404249', '#dcddde'
+            plt.rcParams.update({
+                'figure.facecolor': bg, 'axes.facecolor': bg, 'axes.edgecolor': grid,
+                'axes.labelcolor': text, 'text.color': text, 'xtick.color': text,
+                'ytick.color': text, 'grid.color': grid, 'grid.alpha': 0.45,
+            })
 
-        fig, ax = plt.subplots(figsize=(12, 7))
-        colors = plt.cm.tab10.colors
+            fig, ax = plt.subplots(figsize=(12, 7))
+            colors = plt.cm.tab10.colors
 
-        for i, user_id in enumerate(df_first.groupby('user_id').size().sort_values(ascending=False).index):
-            data = df_first[df_first['user_id'] == user_id]
-            user = self.bot.get_user(int(user_id))
-            ax.plot(
-                data['timesent'], data['_1st to date'],
-                label=user.display_name if user else f"User {user_id}",
-                color=colors[i % len(colors)], linewidth=2.5,
-            )
+            for i, user_id in enumerate(df_first.groupby('user_id').size().sort_values(ascending=False).index):
+                data = df_first[df_first['user_id'] == user_id]
+                user = self.bot.get_user(int(user_id))
+                ax.plot(
+                    data['timesent'], data['_1st to date'],
+                    label=user.display_name if user else f"User {user_id}",
+                    color=colors[i % len(colors)], linewidth=2.5,
+                )
 
-        ax.set(ylabel='Cumulative Firsts', title='Firsts to Date')
-        ax.grid(True, linestyle='--')
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%b %Y'))
-        fig.autofmt_xdate(rotation=30, ha='right')
-        ax.legend(loc='upper left', frameon=False)
+            ax.set(ylabel='Cumulative Firsts', title='Firsts to Date')
+            ax.grid(True, linestyle='--')
+            ax.xaxis.set_major_formatter(mdates.DateFormatter('%b %Y'))
+            fig.autofmt_xdate(rotation=30, ha='right')
+            ax.legend(loc='upper left', frameon=False)
 
-        data_stream = io.BytesIO()
-        fig.savefig(data_stream, format='png', bbox_inches='tight', dpi=150, facecolor=bg)
-        plt.close(fig)
+            data_stream = io.BytesIO()
+            fig.savefig(data_stream, format='png', bbox_inches='tight', dpi=150, facecolor=bg)
+            plt.close(fig)
 
-        data_stream.seek(0)
-        embed = discord.Embed(title='Firsts to Date', color=EMBED_COLOR)
-        embed.set_image(url="attachment://first_graph.png")
-        await ctx.send(embed=embed, file=discord.File(data_stream, filename="first_graph.png"))
+            data_stream.seek(0)
+            embed = discord.Embed(title='Firsts to Date', color=EMBED_COLOR)
+            embed.set_image(url="attachment://first_graph.png")
+            await ctx.send(embed=embed, file=discord.File(data_stream, filename="first_graph.png"))
 
-    @commands.command(brief='Graph daily juice over time')
+    @commands.hybrid_command(brief='Graph daily juice over time')
     async def juicegraph(self, ctx):
         """Graph daily juice over time."""
-        df_first = db_ops.get_table_data('firstlist_id')
-        if df_first.empty:
-            await ctx.send("No firsts recorded yet — claim one with `_1st`!")
-            return
+        async with acknowledge(ctx):
+            df_first = db_ops.get_table_data('firstlist_id')
+            if df_first.empty:
+                await ctx.send("No firsts recorded yet — claim one with `/1st`!")
+                return
 
-        df_juice = juice_calc.daily_juice_series(df_first)
-        _, highscore_user_id, highscore_value = juice_calc.calculate_juice(df_first)
+            df_juice = juice_calc.daily_juice_series(df_first)
+            _, highscore_user_id, highscore_value = juice_calc.calculate_juice(df_first)
 
-        bg, grid, text = '#2b2d31', '#404249', '#dcddde'
-        plt.rcParams.update({
-            'figure.facecolor': bg, 'axes.facecolor': bg, 'axes.edgecolor': grid,
-            'axes.labelcolor': text, 'text.color': text, 'xtick.color': text,
-            'ytick.color': text, 'grid.color': grid, 'grid.alpha': 0.45,
-        })
+            bg, grid, text = '#2b2d31', '#404249', '#dcddde'
+            plt.rcParams.update({
+                'figure.facecolor': bg, 'axes.facecolor': bg, 'axes.edgecolor': grid,
+                'axes.labelcolor': text, 'text.color': text, 'xtick.color': text,
+                'ytick.color': text, 'grid.color': grid, 'grid.alpha': 0.45,
+            })
 
-        fig, ax = plt.subplots(figsize=(12, 7))
-        ax.plot(
-            df_juice['timesent'], df_juice['juice'],
-            color=f'#{EMBED_COLOR:06x}', linewidth=2.5,
-        )
+            fig, ax = plt.subplots(figsize=(12, 7))
+            ax.plot(
+                df_juice['timesent'], df_juice['juice'],
+                color=f'#{EMBED_COLOR:06x}', linewidth=2.5,
+            )
 
-        ax.set(ylabel='Juice', title='Daily Juice')
-        ax.grid(True, linestyle='--')
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%b %Y'))
-        fig.autofmt_xdate(rotation=30, ha='right')
+            ax.set(ylabel='Juice', title='Daily Juice')
+            ax.grid(True, linestyle='--')
+            ax.xaxis.set_major_formatter(mdates.DateFormatter('%b %Y'))
+            fig.autofmt_xdate(rotation=30, ha='right')
 
-        data_stream = io.BytesIO()
-        fig.savefig(data_stream, format='png', bbox_inches='tight', dpi=150, facecolor=bg)
-        plt.close(fig)
+            data_stream = io.BytesIO()
+            fig.savefig(data_stream, format='png', bbox_inches='tight', dpi=150, facecolor=bg)
+            plt.close(fig)
 
-        data_stream.seek(0)
-        highscore_user = self.bot.get_user(int(highscore_user_id))
-        highscore_name = highscore_user.display_name if highscore_user else f"User {highscore_user_id}"
-        embed = discord.Embed(title='Daily Juice', color=EMBED_COLOR)
-        embed.set_footer(text=f'1-Day Highscore: {highscore_name} 🧃{int(highscore_value)} mins')
-        embed.set_image(url="attachment://juice_graph.png")
-        await ctx.send(embed=embed, file=discord.File(data_stream, filename="juice_graph.png"))
+            data_stream.seek(0)
+            highscore_user = self.bot.get_user(int(highscore_user_id))
+            highscore_name = highscore_user.display_name if highscore_user else f"User {highscore_user_id}"
+            embed = discord.Embed(title='Daily Juice', color=EMBED_COLOR)
+            embed.set_footer(text=f'1-Day Highscore: {highscore_name} 🧃{int(highscore_value)} mins')
+            embed.set_image(url="attachment://juice_graph.png")
+            await ctx.send(embed=embed, file=discord.File(data_stream, filename="juice_graph.png"))
 
 async def setup(bot):
-    await bot.add_cog(First(bot)) 
+    await bot.add_cog(First(bot))

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -1,13 +1,14 @@
 import discord
 from discord.ext import commands
 
+
 class Misc(commands.Cog):
     """Miscellaneous commands."""
     
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(brief='Show the donation board')
+    @commands.hybrid_command(brief='Show the donation board')
     async def donation(self, ctx):
         """Show the donation board."""
         embed=discord.Embed(title='Donation Board',description='Thank you to our generous patrons!',color=0x4d4170)
@@ -18,7 +19,7 @@ class Misc(commands.Cog):
         embed.add_field(name='Mike S',value=f'${(8.01+6.68):.2f}',inline=False)
         embed.add_field(name='Whike',value=f'${(6.00):.2f}',inline=False)
         embed.set_footer(text='Peter Dinklage is a non-profit')
-        await ctx.channel.send(embed=embed)
+        await ctx.send(embed=embed)
 
 async def setup(bot):
-    await bot.add_cog(Misc(bot)) 
+    await bot.add_cog(Misc(bot))

--- a/cogs/server.py
+++ b/cogs/server.py
@@ -80,7 +80,7 @@ class Server(commands.Cog):
         seconds_until_next_hour = (next_hour - now).total_seconds()
         await asyncio.sleep(seconds_until_next_hour)
 
-    @commands.command(brief='Refresh member info for the dashboard')
+    @commands.hybrid_command(brief='Refresh member info for the dashboard')
     async def members(self, ctx):
         """Refresh member info for the dashboard."""
         members = ctx.guild.members
@@ -95,9 +95,9 @@ class Server(commands.Cog):
             member_data.append([id, user_name, display_name, avatar, created_at])
             
         db_ops.update_members(member_data)
-        await ctx.channel.send("Member info successfully updated.")
+        await ctx.send("Member info successfully updated.")
 
-    @commands.command(brief='Refresh emoji info for the dashboard')
+    @commands.hybrid_command(brief='Refresh emoji info for the dashboard')
     async def emojis(self, ctx):
         """Refresh emoji info for the dashboard."""
         emoji_data = []
@@ -110,9 +110,9 @@ class Server(commands.Cog):
             emoji_data.append([id, emoji_name, guild_id, url, created_at])
         
         db_ops.update_emojis(emoji_data)
-        await ctx.channel.send("Emoji info successfully updated.")
+        await ctx.send("Emoji info successfully updated.")
 
-    @commands.command(brief='Refresh channel info for the dashboard')
+    @commands.hybrid_command(brief='Refresh channel info for the dashboard')
     async def channels(self, ctx):
         """Refresh channel info for the dashboard."""
         channel_data = []
@@ -123,7 +123,7 @@ class Server(commands.Cog):
             channel_data.append([id, name, created_at])
         
         db_ops.update_channels(channel_data)
-        await ctx.channel.send("Channel info successfully updated.")
+        await ctx.send("Channel info successfully updated.")
 
 async def setup(bot):
-    await bot.add_cog(Server(bot)) 
+    await bot.add_cog(Server(bot))

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1,4 +1,6 @@
+from discord import app_commands
 from discord.ext import commands
+
 
 class Utility(commands.Cog):
     """Simple utility commands."""
@@ -6,22 +8,23 @@ class Utility(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(brief='Say hello')
+    @commands.hybrid_command(brief='Say hello')
     async def hello(self, ctx):
         """Say hello."""
         Author = ctx.author.mention
         msg = f'Hello {Author}!'
-        await ctx.channel.send(msg)
+        await ctx.send(msg)
 
-    @commands.command(brief='Check if the bot is online')
+    @commands.hybrid_command(brief='Check if the bot is online')
     async def ping(self, ctx):
         """Check if the bot is online."""
-        await ctx.channel.send('pong')
+        await ctx.send('pong')
 
-    @commands.command(brief='Make the bot repeat your message')
-    async def simonsays(self, ctx, *, arg):
+    @commands.hybrid_command(brief='Make the bot repeat your message')
+    @app_commands.describe(message='The message for the bot to repeat')
+    async def simonsays(self, ctx, *, message: str):
         """Make the bot repeat your message."""
-        await ctx.channel.send(arg)
+        await ctx.send(message)
 
 async def setup(bot):
-    await bot.add_cog(Utility(bot)) 
+    await bot.add_cog(Utility(bot))

--- a/docs/self_knowledge/ai_features.md
+++ b/docs/self_knowledge/ai_features.md
@@ -3,18 +3,18 @@
 These are your AI-powered features. When explaining them to members, focus on
 **what they can do** — not how you work under the hood.
 
-## Chat — `_ask <question>`
+## Chat — `/ask`
 
 - Ask you anything. You can look things up on the web when needed.
 - **One shared conversation for the whole server** — everyone contributes to the
   same chat thread, not separate threads per person.
 - After a while the conversation resets on its own so it doesn't grow forever.
-  `_clear` starts fresh immediately if someone wants a clean slate.
-- **Images**: attach a picture to the `_ask` message and you can see and talk
-  about it. Starting a message with an image begins a new conversation (the
-  previous thread isn't continued).
+  `/clear` starts fresh immediately if someone wants a clean slate.
+- **Images**: attach a picture with `/ask` (or to a `_ask` message) and you can
+  see and talk about it. Starting a message with an image begins a new
+  conversation (the previous thread isn't continued).
 
-## Image generation — `_imagine <prompt>`
+## Image generation — `/imagine`
 
 - Describe what you want and the bot generates an image.
 - Attach **1–3 images** to edit or combine them.
@@ -22,20 +22,20 @@ These are your AI-powered features. When explaining them to members, focus on
   and `<IMAGE_2>` in your prompt (e.g. “put the person from `<IMAGE_0>` into the
   scene from `<IMAGE_1>`”).
 
-## Voice — `_voice <prompt>`
+## Voice — `/voice`
 
 - You answer the prompt in text, then read that answer aloud as an MP3 file in
   the channel.
 
-## Session reset — `_clear`
+## Session reset — `/clear`
 
-- Wipes the current shared chat memory so the next `_ask` or `_voice` starts over
+- Wipes the current shared chat memory so the next `/ask` or `/voice` starts over
   with no context from earlier messages.
 
 ## Tips for members
 
-- Be specific in prompts for better `_imagine` results. When combining photos,
+- Be specific in prompts for better `/imagine` results. When combining photos,
   name which attachment is which with `<IMAGE_0>` / `<IMAGE_1>` / `<IMAGE_2>`.
-- If the bot seems stuck on an old topic, someone can run `_clear`.
-- `_ask` works best for questions; `_imagine` is for pictures; `_voice` is when
+- If the bot seems stuck on an old topic, someone can run `/clear`.
+- `/ask` works best for questions; `/imagine` is for pictures; `/voice` is when
   they want to hear a reply.

--- a/docs/self_knowledge/dinkcoin.md
+++ b/docs/self_knowledge/dinkcoin.md
@@ -6,15 +6,15 @@ on any blockchain or crypto wallet.
 
 ## How to get DINK
 
-- Win the daily `_1st` game. Each win earns **1 DINK**.
+- Win the daily `/1st` game. Each win earns **1 DINK**.
 - That is the only way new DINK enters the server — nobody can print it except
   by winning first.
 
 ## How to use DINK
 
-- `_balance` — see how much DINK you have.
-- `_ledger` — see who holds the most DINK on the server (top 10 by default, up to 20).
-- `_pay @user <amount>` — send DINK to another member.
+- `/balance` — see how much DINK you have.
+- `/ledger` — see who holds the most DINK on the server (top 10 by default, up to 20).
+- `/pay` — send DINK to another member (pick the user and amount).
 
 ## Rules for paying
 
@@ -26,6 +26,6 @@ on any blockchain or crypto wallet.
 
 | Command | What it does |
 |---------|--------------|
-| `_balance` | Your DINK balance |
-| `_ledger [limit]` | Top holders + total DINK on the server |
-| `_pay @user <amount>` | Send DINK to someone |
+| `/balance` | Your DINK balance |
+| `/ledger [limit]` | Top holders + total DINK on the server |
+| `/pay` | Send DINK to someone |

--- a/docs/self_knowledge/first_game.md
+++ b/docs/self_knowledge/first_game.md
@@ -4,7 +4,7 @@ The most popular game on the server: be the first person to claim the day.
 
 ## How to play
 
-- Type `_1st` in **#general**. It won't work in other channels — the bot will
+- Type `/1st` in **#general**. It won't work in other channels — the bot will
   tell you to go to #general.
 - Only **one person** wins each day. A new day starts at **midnight US/Eastern**.
 - If you win, the bot announces it and you earn **1 DINK** (see the `dinkcoin` topic).
@@ -13,29 +13,29 @@ The most popular game on the server: be the first person to claim the day.
 
 ## Stats and scores
 
-- **Score** — how many daily wins you have total. `_score` shows the top 5
+- **Score** — how many daily wins you have total. `/score` shows the top 5
   players plus the most recent winner and their current streak.
-- **Streak** — how many days in a row the same person has won first. `_stats`
-  (optionally `@someone`) shows a player's total wins, juice, and their longest
+- **Streak** — how many days in a row the same person has won first. `/stats`
+  (optionally pick a user) shows a player's total wins, juice, and their longest
   ever streak.
 - **Juice 🧃** — a lateness score where **more juice is better**. Each win earns
   the number of **minutes past midnight Eastern** when you claimed (e.g. 12:07am
   = 7 juice; 11:30pm = 1410). The strategy is to **wait as long as possible**
-  before typing `_1st` — claim late in the day to maximize your juice. Early
+  before typing `/1st` — claim late in the day to maximize your juice. Early
   claims earn less; late claims earn more.
 - If nobody claims for a full day, the next winner also picks up 1440 juice per
   missed day on top of their within-day minutes.
-- **Total juice** (sum across all your wins) is what `_juice` ranks — the
+- **Total juice** (sum across all your wins) is what `/juice` ranks — the
   leaderboard goes to whoever has accumulated the most juice over time.
-- `_juice` also shows the single-day high score (most juice earned in one claim).
+- `/juice` also shows the single-day high score (most juice earned in one claim).
 
 ## Commands
 
 | Command | What it does |
 |---------|--------------|
-| `_1st` | Claim first for today (#general only, once per day) |
-| `_score` | Top 5 wins + most recent winner and streak |
-| `_stats [@user]` | One player's wins, juice, and longest streak |
-| `_juice` | Top 5 juice + single-day high score |
-| `_graph` | Chart of cumulative firsts over time |
-| `_juicegraph` | Chart of daily juice over time |
+| `/1st` | Claim first for today (#general only, once per day) |
+| `/score` | Top 5 wins + most recent winner and streak |
+| `/stats [user]` | One player's wins, juice, and longest streak |
+| `/juice` | Top 5 juice + single-day high score |
+| `/graph` | Chart of cumulative firsts over time |
+| `/juicegraph` | Chart of daily juice over time |

--- a/docs/self_knowledge/overview.md
+++ b/docs/self_knowledge/overview.md
@@ -1,23 +1,23 @@
 # About Peter Dinklage
 
 You are **Peter Dinklage**, the resident bot of the Dinkscord Discord server.
-Members interact with you using commands that start with `_` (underscore). Commands
-are case-insensitive.
+Members interact with you using **slash commands** (type `/` to see them). The
+older `_` prefix still works. Commands are case-insensitive.
 
 ## What you do for the server
 
 - **Daily "first" game** — members race to claim the first win of the day with
-  `_1st`. Wins, streaks, and juice scores are tracked, with leaderboards and
+  `/1st`. Wins, streaks, and juice scores are tracked, with leaderboards and
   graphs. See the `first_game` topic for the full rules.
-- **DinkCoin (DINK)** — a fun server currency earned by winning `_1st` and sent
-  between members with `_pay`. See the `dinkcoin` topic.
-- **Chat & creativity** — `_ask` for questions and conversation (including images
-  you attach), `_imagine` for AI art, `_voice` for a spoken reply, and `_clear`
+- **DinkCoin (DINK)** — a fun server currency earned by winning `/1st` and sent
+  between members with `/pay`. See the `dinkcoin` topic.
+- **Chat & creativity** — `/ask` for questions and conversation (including images
+  you attach), `/imagine` for AI art, `/voice` for a spoken reply, and `/clear`
   to start a fresh chat. See the `ai_features` topic.
 - **Server stats** — you keep track of activity on the server and post a monthly
   report. Stats are also on the public dashboard at
   https://peterdinklage.streamlit.app/. See the `server_stats` topic.
-- **Fun & utilities** — `_ping`, `_hello`, `_simonsays`, and `_donation` (a thank-you
+- **Fun & utilities** — `/ping`, `/hello`, `/simonsays`, and `/donation` (a thank-you
   list of patrons who help keep the bot running).
 
 ## How to talk about yourself

--- a/docs/self_knowledge/server_stats.md
+++ b/docs/self_knowledge/server_stats.md
@@ -6,10 +6,10 @@ leaderboards, graphs, and the monthly report — not through raw data.
 ## What gets tracked
 
 - **Messages** — activity in channels (used for monthly rankings and the dashboard).
-- **First game** — every daily `_1st` win, which powers `_score`, `_stats`, `_juice`,
+- **First game** — every daily `/1st` win, which powers `/score`, `/stats`, `/juice`,
   and the graphs.
-- **DINK** — balances and transfers from `_pay` and `_1st` wins.
-- **AI usage** — `_ask`, `_imagine`, and related commands (for server records).
+- **DINK** — balances and transfers from `/pay` and `/1st` wins.
+- **AI usage** — `/ask`, `/imagine`, and related commands (for server records).
 
 ## What members see
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-discord
+discord.py>=2.3.0
 pymysql
 pandas
 matplotlib
 pytz
+tzdata
 requests
 python-dotenv
 xai-sdk>=1.17.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,11 +91,13 @@ def mock_ctx(mock_author):
     ctx.message.author = mock_author
     ctx.message.mentions = []
     ctx.message.attachments = []
+    ctx.interaction = None
 
     typing_cm = AsyncMock()
     typing_cm.__aenter__ = AsyncMock(return_value=None)
     typing_cm.__aexit__ = AsyncMock(return_value=None)
     ctx.typing = MagicMock(return_value=typing_cm)
+    ctx.defer = AsyncMock()
 
     return ctx
 

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -24,7 +24,7 @@ async def test_ask_success(report, ai_cog, mock_ctx):
     expected = "Grok says hi"
     ai_cog.grok.send_message.return_value = ("new-id", expected)
 
-    await ai_cog.ask.callback(ai_cog, mock_ctx, arg="hello grok")
+    await ai_cog.ask.callback(ai_cog, mock_ctx, prompt="hello grok")
 
     actual = mock_ctx.send.call_args.args[0]
     report.record("ctx.send", expected, actual, section=SECTION_COMMANDS)
@@ -41,7 +41,7 @@ async def test_ask_api_error(report, ai_cog, mock_ctx):
     expected = "Something broke on my end, dude. Check the bot logs and try again."
     ai_cog.grok.send_message.side_effect = RuntimeError("API down")
 
-    await ai_cog.ask.callback(ai_cog, mock_ctx, arg="hello")
+    await ai_cog.ask.callback(ai_cog, mock_ctx, prompt="hello")
 
     actual = mock_ctx.send.call_args.args[0]
     report.record("error message", expected, actual, section=SECTION_COMMANDS)
@@ -73,7 +73,7 @@ async def test_imagine_success(mock_imagine, report, mock_db_ops, ai_cog, mock_c
         "revised_prompt": None,
     }
 
-    await ai_cog.imagine.callback(ai_cog, mock_ctx, arg="a red circle")
+    await ai_cog.imagine.callback(ai_cog, mock_ctx, prompt="a red circle")
 
     sent_file = mock_ctx.send.call_args.kwargs.get("file")
     report.record("imagine status", "success", mock_imagine.return_value["status"], section=SECTION_COMMANDS)
@@ -100,7 +100,7 @@ async def test_imagine_with_multiple_input_images(mock_imagine, report, mock_db_
     }
 
     prompt = "Put the person from <IMAGE_0> into the scene from <IMAGE_1>"
-    await ai_cog.imagine.callback(ai_cog, mock_ctx, arg=prompt)
+    await ai_cog.imagine.callback(ai_cog, mock_ctx, prompt=prompt)
 
     mock_imagine.assert_called_once_with(prompt, input_image_urls=urls)
     embed = mock_ctx.send.call_args.kwargs["embed"]
@@ -117,9 +117,9 @@ async def test_imagine_rejects_too_many_images(mock_imagine, report, mock_db_ops
         for i in range(MAX_IMAGINE_INPUT_IMAGES + 1)
     ]
 
-    await ai_cog.imagine.callback(ai_cog, mock_ctx, arg="combine these")
+    await ai_cog.imagine.callback(ai_cog, mock_ctx, prompt="combine these")
 
-    expected = f"You can attach at most {MAX_IMAGINE_INPUT_IMAGES} images for `_imagine`."
+    expected = f"You can attach at most {MAX_IMAGINE_INPUT_IMAGES} images for `/imagine`."
     actual = mock_ctx.send.call_args.args[0]
     report.record("too many images message", expected, actual, section=SECTION_COMMANDS)
     mock_imagine.assert_not_called()
@@ -130,7 +130,7 @@ async def test_imagine_rejects_too_many_images(mock_imagine, report, mock_db_ops
 async def test_imagine_failure(mock_imagine, report, ai_cog, mock_ctx):
     mock_imagine.return_value = {"status": "error", "error": "rate limited"}
 
-    await ai_cog.imagine.callback(ai_cog, mock_ctx, arg="a red circle")
+    await ai_cog.imagine.callback(ai_cog, mock_ctx, prompt="a red circle")
 
     embed = mock_ctx.send.call_args.kwargs["embed"]
     expected_desc = "Failed to generate image. Check the bot logs and try again."
@@ -156,7 +156,7 @@ def test_imagine_has_hourly_rate_limit(report, ai_cog):
 
 async def test_imagine_cooldown_error_message(report, mock_ctx):
     expected = (
-        "You've hit the `_imagine` limit (30 per hour). "
+        "You've hit the `/imagine` limit (30 per hour). "
         "Try again in about 4 minutes."
     )
     bot = DinkBot.__new__(DinkBot)
@@ -183,7 +183,7 @@ async def test_voice_success(mock_getenv, mock_post, report, ai_cog, mock_ctx):
     mock_response.raise_for_status = MagicMock()
     mock_post.return_value = mock_response
 
-    await ai_cog.voice.callback(ai_cog, mock_ctx, text="say hello")
+    await ai_cog.voice.callback(ai_cog, mock_ctx, prompt="say hello")
 
     audio_file = mock_ctx.send.call_args.kwargs["file"]
     report.record("grok reply", "spoken text", ai_cog.grok.send_message.return_value[1], section=SECTION_COMMANDS)
@@ -198,7 +198,7 @@ async def test_voice_success(mock_getenv, mock_post, report, ai_cog, mock_ctx):
 @patch("cogs.ai.os.getenv", return_value=None)
 async def test_voice_missing_api_key(_mock_getenv, report, ai_cog, mock_ctx):
     expected = "XAI API key not configured."
-    await ai_cog.voice.callback(ai_cog, mock_ctx, text="hello")
+    await ai_cog.voice.callback(ai_cog, mock_ctx, prompt="hello")
 
     actual = mock_ctx.send.call_args.args[0]
     report.record("error message", expected, actual, section=SECTION_COMMANDS)
@@ -214,7 +214,7 @@ async def test_voice_tts_failure_hides_exception(mock_getenv, mock_post, report,
     ai_cog.grok.send_message.return_value = ("tts-id", "spoken text")
     mock_post.side_effect = requests.exceptions.RequestException("connection reset")
 
-    await ai_cog.voice.callback(ai_cog, mock_ctx, text="say hello")
+    await ai_cog.voice.callback(ai_cog, mock_ctx, prompt="say hello")
 
     actual = mock_ctx.send.call_args.args[0]
     report.record("error message", expected, actual, section=SECTION_COMMANDS)

--- a/tests/test_first_commands.py
+++ b/tests/test_first_commands.py
@@ -29,9 +29,9 @@ async def test_first_wrong_channel(report, mock_bot, mock_ctx):
 
     await cog.first.callback(cog, mock_ctx)
 
-    actual = mock_ctx.channel.send.call_args.args[0]
-    report.record("channel.send", expected, actual, section=SECTION_COMMANDS)
-    mock_ctx.channel.send.assert_awaited_once_with(expected)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("ctx.send", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.send.assert_awaited_once_with(expected)
 
 
 @patch("cogs.first.asyncio.sleep", new_callable=AsyncMock)
@@ -49,13 +49,13 @@ async def test_first_successful_claim(
     cog = First(mock_bot)
     await cog.first.callback(cog, mock_ctx)
 
-    actual = mock_ctx.channel.send.call_args.args[0]
-    report.record("channel.send", expected, actual, section=SECTION_COMMANDS)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("ctx.send", expected, actual, section=SECTION_COMMANDS)
     report.record("db write", mock_ctx.author.id, mock_db_ops.write_first_entry.call_args.args[0], section=SECTION_COMMANDS)
 
     mock_db_ops.write_first_entry.assert_called_once_with(mock_ctx.author.id)
     mock_db_ops.record_dink_mint.assert_called_once_with(mock_ctx.author.id, 1.0)
-    mock_ctx.channel.send.assert_awaited_once_with(expected)
+    mock_ctx.send.assert_awaited_once_with(expected)
 
 
 @patch("cogs.first.datetime")
@@ -70,12 +70,12 @@ async def test_first_already_claimed_today(mock_datetime, report, mock_db_ops, m
     cog = First(mock_bot)
     await cog.first.callback(cog, mock_ctx)
 
-    actual = mock_ctx.channel.send.call_args.args[0]
-    report.record("channel.send", expected, actual, section=SECTION_COMMANDS)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("ctx.send", expected, actual, section=SECTION_COMMANDS)
     report.record("db write", "not called", mock_db_ops.write_first_entry.called, section=SECTION_COMMANDS)
 
     mock_db_ops.write_first_entry.assert_not_called()
-    mock_ctx.channel.send.assert_awaited_once_with(expected)
+    mock_ctx.send.assert_awaited_once_with(expected)
 
 
 async def test_score(report, mock_db_ops, mock_bot, mock_ctx, leaderboard_first_df):
@@ -84,11 +84,11 @@ async def test_score(report, mock_db_ops, mock_bot, mock_ctx, leaderboard_first_
 
     await cog.score.callback(cog, mock_ctx)
 
-    embed = mock_ctx.channel.send.call_args.kwargs["embed"]
+    embed = mock_ctx.send.call_args.kwargs["embed"]
     report.record("embed title", "First Leaderboard", embed.title, section=SECTION_COMMANDS)
     report.record("embed field count", 5, len(embed.fields), section=SECTION_COMMANDS)
 
-    mock_ctx.channel.send.assert_awaited_once()
+    mock_ctx.send.assert_awaited_once()
     assert embed.title == "First Leaderboard"
     assert len(embed.fields) == 5
 
@@ -101,11 +101,11 @@ async def test_stats_self(report, mock_db_ops, mock_bot, mock_ctx, sample_first_
 
     await cog.stats.callback(cog, mock_ctx)
 
-    embed = mock_ctx.channel.send.call_args.kwargs["embed"]
+    embed = mock_ctx.send.call_args.kwargs["embed"]
     report.record("embed field count", 3, len(embed.fields), section=SECTION_COMMANDS)
     report.record("embed has title", True, embed.title is not None, section=SECTION_COMMANDS)
 
-    mock_ctx.channel.send.assert_awaited_once()
+    mock_ctx.send.assert_awaited_once()
     assert embed.title is not None
     assert len(embed.fields) == 3
 
@@ -120,9 +120,9 @@ async def test_stats_no_entries(report, mock_db_ops, mock_bot, mock_ctx):
 
     await cog.stats.callback(cog, mock_ctx)
 
-    actual = mock_ctx.channel.send.call_args.args[0]
-    report.record("channel.send", expected, actual, section=SECTION_COMMANDS)
-    mock_ctx.channel.send.assert_awaited_once_with(expected)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("ctx.send", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.send.assert_awaited_once_with(expected)
 
 
 async def test_juice(report, mock_db_ops, mock_bot, mock_ctx, leaderboard_first_df):
@@ -131,10 +131,10 @@ async def test_juice(report, mock_db_ops, mock_bot, mock_ctx, leaderboard_first_
 
     await cog.juice.callback(cog, mock_ctx)
 
-    embed = mock_ctx.channel.send.call_args.kwargs["embed"]
+    embed = mock_ctx.send.call_args.kwargs["embed"]
     report.record("embed title", "Juice Board 🧃", embed.title, section=SECTION_COMMANDS)
 
-    mock_ctx.channel.send.assert_awaited_once()
+    mock_ctx.send.assert_awaited_once()
     assert embed.title == "Juice Board 🧃"
 
 
@@ -153,25 +153,25 @@ async def test_first_empty_table_allows_claim(
     cog = First(mock_bot)
     await cog.first.callback(cog, mock_ctx)
 
-    actual = mock_ctx.channel.send.call_args.args[0]
-    report.record("channel.send", expected, actual, section=SECTION_COMMANDS)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("ctx.send", expected, actual, section=SECTION_COMMANDS)
     report.record("db write", mock_ctx.author.id, mock_db_ops.write_first_entry.call_args.args[0], section=SECTION_COMMANDS)
 
     mock_db_ops.write_first_entry.assert_called_once_with(mock_ctx.author.id)
     mock_db_ops.record_dink_mint.assert_called_once_with(mock_ctx.author.id, 1.0)
-    mock_ctx.channel.send.assert_awaited_once_with(expected)
+    mock_ctx.send.assert_awaited_once_with(expected)
 
 
 async def test_score_empty(report, mock_db_ops, mock_bot, mock_ctx, empty_first_df):
-    expected = "No firsts recorded yet — claim one with `_1st`!"
+    expected = "No firsts recorded yet — claim one with `/1st`!"
     mock_db_ops.get_table_data.return_value = empty_first_df
     cog = First(mock_bot)
 
     await cog.score.callback(cog, mock_ctx)
 
-    actual = mock_ctx.channel.send.call_args.args[0]
-    report.record("channel.send", expected, actual, section=SECTION_COMMANDS)
-    mock_ctx.channel.send.assert_awaited_once_with(expected)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("ctx.send", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.send.assert_awaited_once_with(expected)
 
 
 async def test_score_fewer_than_five_winners(report, mock_db_ops, mock_bot, mock_ctx, sample_first_df):
@@ -180,24 +180,24 @@ async def test_score_fewer_than_five_winners(report, mock_db_ops, mock_bot, mock
 
     await cog.score.callback(cog, mock_ctx)
 
-    embed = mock_ctx.channel.send.call_args.kwargs["embed"]
+    embed = mock_ctx.send.call_args.kwargs["embed"]
     # sample_first_df has 2 distinct users
     report.record("embed field count", 2, len(embed.fields), section=SECTION_COMMANDS)
-    mock_ctx.channel.send.assert_awaited_once()
+    mock_ctx.send.assert_awaited_once()
     assert embed.title == "First Leaderboard"
     assert len(embed.fields) == 2
 
 
 async def test_juice_empty(report, mock_db_ops, mock_bot, mock_ctx, empty_first_df):
-    expected = "No firsts recorded yet — claim one with `_1st`!"
+    expected = "No firsts recorded yet — claim one with `/1st`!"
     mock_db_ops.get_table_data.return_value = empty_first_df
     cog = First(mock_bot)
 
     await cog.juice.callback(cog, mock_ctx)
 
-    actual = mock_ctx.channel.send.call_args.args[0]
-    report.record("channel.send", expected, actual, section=SECTION_COMMANDS)
-    mock_ctx.channel.send.assert_awaited_once_with(expected)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("ctx.send", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.send.assert_awaited_once_with(expected)
 
 
 async def test_juice_fewer_than_five_winners(report, mock_db_ops, mock_bot, mock_ctx, sample_first_df):
@@ -206,15 +206,15 @@ async def test_juice_fewer_than_five_winners(report, mock_db_ops, mock_bot, mock
 
     await cog.juice.callback(cog, mock_ctx)
 
-    embed = mock_ctx.channel.send.call_args.kwargs["embed"]
+    embed = mock_ctx.send.call_args.kwargs["embed"]
     report.record("embed field count", 2, len(embed.fields), section=SECTION_COMMANDS)
-    mock_ctx.channel.send.assert_awaited_once()
+    mock_ctx.send.assert_awaited_once()
     assert embed.title == "Juice Board 🧃"
     assert len(embed.fields) == 2
 
 
 async def test_graph_empty(report, mock_db_ops, mock_bot, mock_ctx, empty_first_df):
-    expected = "No firsts recorded yet — claim one with `_1st`!"
+    expected = "No firsts recorded yet — claim one with `/1st`!"
     mock_db_ops.get_table_data.return_value = empty_first_df
     cog = First(mock_bot)
 

--- a/tests/test_misc_commands.py
+++ b/tests/test_misc_commands.py
@@ -10,12 +10,12 @@ async def test_donation(report, mock_bot, mock_ctx):
     cog = Misc(mock_bot)
     await cog.donation.callback(cog, mock_ctx)
 
-    embed = mock_ctx.channel.send.call_args.kwargs.get("embed") or mock_ctx.channel.send.call_args.args[0]
+    embed = mock_ctx.send.call_args.kwargs.get("embed") or mock_ctx.send.call_args.args[0]
     report.record("embed title", "Donation Board", embed.title, section=SECTION_COMMANDS)
     report.record("embed field count", 6, len(embed.fields), section=SECTION_COMMANDS)
     report.record("footer", "Peter Dinklage is a non-profit", embed.footer.text, section=SECTION_COMMANDS)
 
-    mock_ctx.channel.send.assert_awaited_once()
+    mock_ctx.send.assert_awaited_once()
     assert isinstance(embed, discord.Embed)
     assert embed.title == "Donation Board"
     assert embed.footer.text == "Peter Dinklage is a non-profit"

--- a/tests/test_self_knowledge.py
+++ b/tests/test_self_knowledge.py
@@ -59,9 +59,9 @@ def test_build_command_reference_lists_real_commands(report, mock_bot):
     fake_bot.cogs = {"Utility": Utility(mock_bot)}
     reference = self_knowledge.build_command_reference(fake_bot)
 
-    assert "_ping" in reference
-    assert "_hello" in reference
-    assert_eq(report, SECTION_SELF_KNOWLEDGE, "command reference", "lists _ping", "lists _ping")
+    assert "/ping" in reference
+    assert "/hello" in reference
+    assert_eq(report, SECTION_SELF_KNOWLEDGE, "command reference", "lists /ping", "lists /ping")
 
 
 def test_get_first_game_stats(report, mock_db_ops, sample_first_df):

--- a/tests/test_server_commands.py
+++ b/tests/test_server_commands.py
@@ -43,13 +43,13 @@ async def test_members(report, mock_db_ops, mock_bot, mock_ctx):
     rows = mock_db_ops.update_members.call_args.args[0]
     report.record("member id", 111, rows[0][0], section=SECTION_COMMANDS)
     report.record("member username", "alice", rows[0][1], section=SECTION_COMMANDS)
-    report.record("confirmation", "Member info successfully updated.", mock_ctx.channel.send.call_args.args[0], section=SECTION_COMMANDS)
+    report.record("confirmation", "Member info successfully updated.", mock_ctx.send.call_args.args[0], section=SECTION_COMMANDS)
 
     mock_db_ops.update_members.assert_called_once()
     assert len(rows) == 1
     assert rows[0][0] == 111
     assert rows[0][1] == "alice"
-    mock_ctx.channel.send.assert_awaited_once_with("Member info successfully updated.")
+    mock_ctx.send.assert_awaited_once_with("Member info successfully updated.")
 
 
 async def test_emojis(report, mock_db_ops, mock_bot, mock_ctx):
@@ -67,11 +67,11 @@ async def test_emojis(report, mock_db_ops, mock_bot, mock_ctx):
 
     rows = mock_db_ops.update_emojis.call_args.args[0]
     report.record("emoji name", "pepe", rows[0][1], section=SECTION_COMMANDS)
-    report.record("confirmation", "Emoji info successfully updated.", mock_ctx.channel.send.call_args.args[0], section=SECTION_COMMANDS)
+    report.record("confirmation", "Emoji info successfully updated.", mock_ctx.send.call_args.args[0], section=SECTION_COMMANDS)
 
     mock_db_ops.update_emojis.assert_called_once()
     assert rows[0][1] == "pepe"
-    mock_ctx.channel.send.assert_awaited_once_with("Emoji info successfully updated.")
+    mock_ctx.send.assert_awaited_once_with("Emoji info successfully updated.")
 
 
 async def test_channels(report, mock_db_ops, mock_bot, mock_ctx):
@@ -88,9 +88,9 @@ async def test_channels(report, mock_db_ops, mock_bot, mock_ctx):
     rows = mock_db_ops.update_channels.call_args.args[0]
     report.record("channel id", 444, rows[0][0], section=SECTION_COMMANDS)
     report.record("channel name", "general", rows[0][1], section=SECTION_COMMANDS)
-    report.record("confirmation", "Channel info successfully updated.", mock_ctx.channel.send.call_args.args[0], section=SECTION_COMMANDS)
+    report.record("confirmation", "Channel info successfully updated.", mock_ctx.send.call_args.args[0], section=SECTION_COMMANDS)
 
     mock_db_ops.update_channels.assert_called_once()
     assert rows[0][0] == 444
     assert rows[0][1] == "general"
-    mock_ctx.channel.send.assert_awaited_once_with("Channel info successfully updated.")
+    mock_ctx.send.assert_awaited_once_with("Channel info successfully updated.")

--- a/tests/test_utility_commands.py
+++ b/tests/test_utility_commands.py
@@ -8,24 +8,24 @@ async def test_hello(report, mock_bot, mock_ctx):
     expected = "Hello <@123456789>!"
     cog = Utility(mock_bot)
     await cog.hello.callback(cog, mock_ctx)
-    actual = mock_ctx.channel.send.call_args.args[0]
-    report.record("channel.send", expected, actual, section=SECTION_COMMANDS)
-    mock_ctx.channel.send.assert_awaited_once_with(expected)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("ctx.send", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.send.assert_awaited_once_with(expected)
 
 
 async def test_ping(report, mock_bot, mock_ctx):
     expected = "pong"
     cog = Utility(mock_bot)
     await cog.ping.callback(cog, mock_ctx)
-    actual = mock_ctx.channel.send.call_args.args[0]
-    report.record("channel.send", expected, actual, section=SECTION_COMMANDS)
-    mock_ctx.channel.send.assert_awaited_once_with(expected)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("ctx.send", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.send.assert_awaited_once_with(expected)
 
 
 async def test_simonsays(report, mock_bot, mock_ctx):
     expected = "repeat this"
     cog = Utility(mock_bot)
-    await cog.simonsays.callback(cog, mock_ctx, arg=expected)
-    actual = mock_ctx.channel.send.call_args.args[0]
-    report.record("channel.send", expected, actual, section=SECTION_COMMANDS)
-    mock_ctx.channel.send.assert_awaited_once_with(expected)
+    await cog.simonsays.callback(cog, mock_ctx, message=expected)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("ctx.send", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.send.assert_awaited_once_with(expected)

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -20,9 +20,9 @@ MAX_GROK_SESSION_TURNS = 20
 # Grok Imagine multi-reference edit limit (xAI API: up to 3 source images).
 MAX_IMAGINE_INPUT_IMAGES = 3
 
-# Per-user _imagine rate limit (discord.py cooldown: rate uses per period seconds).
+# Per-user /imagine rate limit (discord.py cooldown: rate uses per period seconds).
 IMAGINE_RATE_LIMIT = 30
 IMAGINE_RATE_PERIOD_SECONDS = 3600
 
-# DINK awarded for each successful _1st claim (MySQL ledger only)
+# DINK awarded for each successful /1st claim (MySQL ledger only)
 DINK_MINT_AMOUNT = float(os.getenv("DINK_MINT_AMOUNT", "1"))

--- a/utils/interactions.py
+++ b/utils/interactions.py
@@ -1,0 +1,14 @@
+"""Helpers for hybrid (prefix + slash) command acknowledgements."""
+
+from contextlib import asynccontextmanager
+
+
+@asynccontextmanager
+async def acknowledge(ctx):
+    """Defer slash interactions; show typing for prefix invocations."""
+    if ctx.interaction is not None:
+        await ctx.defer()
+        yield
+    else:
+        async with ctx.typing():
+            yield

--- a/utils/self_knowledge.py
+++ b/utils/self_knowledge.py
@@ -18,9 +18,9 @@ DOCS_DIR = Path(__file__).resolve().parent.parent / "docs" / "self_knowledge"
 # topic name -> one-line description surfaced in the tool schema
 TOPICS = {
     "overview": "What the bot is and what it can do for server members",
-    "first_game": "Rules of the daily _1st game: claiming, score, streaks, and juice",
+    "first_game": "Rules of the daily /1st game: claiming, score, streaks, and juice",
     "dinkcoin": "How DINK works: earning it, spending it, and the leaderboard",
-    "ai_features": "How _ask, _imagine, _voice, and _clear work for members",
+    "ai_features": "How /ask, /imagine, /voice, and /clear work for members",
     "server_stats": "Activity tracking, the monthly report, and the public dashboard",
 }
 
@@ -45,7 +45,7 @@ def build_command_reference(bot) -> str:
             "Live command registry unavailable. Use get_bot_documentation "
             "(topics: overview, first_game, dinkcoin, ai_features) for command lists."
         )
-    lines = ["Commands (prefix '_', case-insensitive):"]
+    lines = ["Commands (slash /name; underscore _name also works, case-insensitive):"]
     for cog_name, cog in bot.cogs.items():
         cog_doc = (cog.__doc__ or "").strip().splitlines()
         lines.append(f"\n{cog_name}: {cog_doc[0] if cog_doc else ''}".rstrip())
@@ -55,7 +55,7 @@ def build_command_reference(bot) -> str:
             params = " ".join(
                 f"<{p}>" for p in cmd.clean_params
             )
-            usage = f"_{cmd.name} {params}".strip()
+            usage = f"/{cmd.name} {params}".strip()
             lines.append(f"  {usage} — {summary}")
     return "\n".join(lines)
 
@@ -138,7 +138,7 @@ TOOL_SCHEMAS = [
         "name": "get_bot_documentation",
         "description": (
             "Look up member-facing documentation about the bot. Use when someone "
-            "asks what you can do, how commands work, the _1st game, juice, DINK, "
+            "asks what you can do, how commands work, the /1st game, juice, DINK, "
             "chat/imagine/voice, or server stats. Answer in plain language for "
             "Discord users — never expose internal implementation details. "
             "Topics: " + "; ".join(f"'{k}' = {v}" for k, v in TOPICS.items())
@@ -179,7 +179,7 @@ TOOL_SCHEMAS = [
             "Fetch live juice leaderboard data: top-10 players by total juice, "
             "who has the most juice overall, and the single-day high score. "
             "Use for any question about who has the most juice, juice rankings, "
-            "or juice records. Higher juice is better — it rewards claiming _1st "
+            "or juice records. Higher juice is better — it rewards claiming /1st "
             "as late in the day as possible."
         ),
         "parameters": {"type": "object", "properties": {}},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The bot only supported `_` prefix commands, so Discord never showed the native `/` autocomplete popup. This migrates all 20 commands to `@commands.hybrid_command`, syncs the application command tree on startup, and keeps the `_` prefix working.

## Changes

- Sync slash commands in `setup_hook` (`DISCORD_GUILD_ID` for instant guild sync; otherwise global)
- Convert all cog commands to hybrid with `@app_commands.describe` option hints
- Defer slow `/ask`, `/imagine`, `/voice`, `/graph`, `/juicegraph` interactions
- Typed options for prompts, members, attachments, and ledger limit
- Update README, self-knowledge docs, and tests; pin `discord.py>=2.3.0`

## After merge

1. Ensure the bot invite includes the **`applications.commands`** scope (re-invite if needed)
2. Optionally set `DISCORD_GUILD_ID` for instant sync; otherwise global sync can take up to ~1 hour
3. After host restart, type `/` in Discord — commands should appear with descriptions

## Test plan

- [x] `./scripts/test.sh -m "not live"` (75 passed)
- [ ] After deploy: `/ping`, `/1st`, `/ask`, `/pay` appear in autocomplete
- [ ] Prefix `_ping` / `_ask` still work
- [ ] Slow commands (`/imagine`, `/ask`) do not show “interaction failed”

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6b66-97d1-79c4-9db8-93e8cda69594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6b66-97d1-79c4-9db8-93e8cda69594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

