### PR TITLE
Fix slash AI command FK errors and optional image args

### DIFF
--- a/cogs/ai.py
+++ b/cogs/ai.py
@@ -46,6 +46,25 @@ def _collect_image_urls(ctx, *attachments: Optional[discord.Attachment]) -> List
     return _image_urls_from_message(ctx)
 
 
+async def _ensure_message_row(ctx, content: str = "") -> None:
+    """Insert a messages row for slash invocations (they skip on_message).
+
+    AI logging FKs chatgpt_logs / dalle_3_prompts.message_id → messages.id.
+    Prefix commands are already stored in on_message before process_commands.
+    """
+    if ctx.interaction is None:
+        return
+    message_data = (
+        ctx.message.id,
+        ctx.author.id,
+        ctx.channel.id,
+        content or (getattr(ctx.message, "content", None) or ""),
+        ctx.message.created_at,
+    )
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, db_ops.update_messages, message_data)
+
+
 class AI(commands.Cog):
     """Chat, image generation, and voice."""
 
@@ -121,7 +140,13 @@ class AI(commands.Cog):
         prompt="Your question or message",
         image="Optional image to include with your question",
     )
-    async def ask(self, ctx, image: discord.Attachment = None, *, prompt: str):
+    async def ask(
+        self,
+        ctx,
+        *,
+        prompt: str,
+        image: Optional[discord.Attachment] = None,
+    ):
         """Ask a question. You can also attach images."""
 
         image_urls = _collect_image_urls(ctx, image)
@@ -132,6 +157,7 @@ class AI(commands.Cog):
                 self._reset_session()
 
             try:
+                await _ensure_message_row(ctx, content=prompt)
                 next_response_id, response_text = self.grok.send_message(
                     prompt,
                     previous_response_id=self.last_response_id,
@@ -162,19 +188,17 @@ class AI(commands.Cog):
     async def imagine(
         self,
         ctx,
-        image1: discord.Attachment = None,
-        image2: discord.Attachment = None,
-        image3: discord.Attachment = None,
         *,
         prompt: str,
+        image1: Optional[discord.Attachment] = None,
+        image2: Optional[discord.Attachment] = None,
+        image3: Optional[discord.Attachment] = None,
     ):
         """Generate an AI image based on a prompt and optional input images.
 
         Attach up to 3 images to edit or combine them; refer to them in the prompt
         as <IMAGE_0>, <IMAGE_1>, <IMAGE_2> (attachment order).
         """
-
-        db_ops.write_dalle_entry(user_id=ctx.author.id, prompt=prompt, message_id=ctx.message.id)
 
         input_image_urls = _collect_image_urls(ctx, image1, image2, image3)
         if len(input_image_urls) > MAX_IMAGINE_INPUT_IMAGES:
@@ -184,6 +208,9 @@ class AI(commands.Cog):
             return
 
         async with acknowledge(ctx):
+            await _ensure_message_row(ctx, content=prompt)
+            db_ops.write_dalle_entry(user_id=ctx.author.id, prompt=prompt, message_id=ctx.message.id)
+
             response = call_grok_imagine(
                 prompt,
                 input_image_urls=input_image_urls or None,
@@ -246,6 +273,7 @@ class AI(commands.Cog):
                 if self._session_turns >= MAX_GROK_SESSION_TURNS:
                     self._reset_session()
 
+                await _ensure_message_row(ctx, content=prompt)
                 next_response_id, response_text = self.grok.send_message(
                     prompt,
                     previous_response_id=self.last_response_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,7 @@ def mock_db_ops(request):
         patch.object(db_ops, "update_members", MagicMock()),
         patch.object(db_ops, "update_emojis", MagicMock()),
         patch.object(db_ops, "update_channels", MagicMock()),
+        patch.object(db_ops, "update_messages", MagicMock()),
         patch.object(db_ops, "log_chatgpt_interaction", MagicMock()),
         patch.object(db_ops, "get_dink_balance", MagicMock(return_value=0.0)),
         patch.object(db_ops, "get_dink_ledger", MagicMock()),

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -37,6 +37,41 @@ async def test_ask_success(report, ai_cog, mock_ctx):
     assert ai_cog._session_turns == 1
 
 
+async def test_ask_slash_inserts_message_row(report, mock_db_ops, ai_cog, mock_ctx):
+    """Slash skips on_message; AI logging FKs message_id → messages.id."""
+    from datetime import datetime, timezone
+
+    mock_ctx.interaction = MagicMock()
+    mock_ctx.message.created_at = datetime(2024, 6, 11, tzinfo=timezone.utc)
+    ai_cog.grok.send_message.return_value = ("new-id", "ok")
+
+    await ai_cog.ask.callback(ai_cog, mock_ctx, prompt="hello slash")
+
+    mock_db_ops.update_messages.assert_called_once()
+    row = mock_db_ops.update_messages.call_args.args[0]
+    report.record("message id logged", mock_ctx.message.id, row[0], section=SECTION_COMMANDS)
+    report.record("message content", "hello slash", row[3], section=SECTION_COMMANDS)
+    assert row[0] == mock_ctx.message.id
+    assert row[3] == "hello slash"
+    ai_cog.grok.send_message.assert_called_once()
+
+
+async def test_ask_prefix_skips_message_insert(report, mock_db_ops, ai_cog, mock_ctx):
+    mock_ctx.interaction = None
+    ai_cog.grok.send_message.return_value = ("new-id", "ok")
+
+    await ai_cog.ask.callback(ai_cog, mock_ctx, prompt="hello prefix")
+
+    mock_db_ops.update_messages.assert_not_called()
+    report.record("prefix message insert", "skipped", "skipped", section=SECTION_COMMANDS)
+
+
+def test_ask_image_option_is_optional(report, ai_cog):
+    param = ai_cog.ask.clean_params["image"]
+    report.record("image required", False, param.required, section=SECTION_COMMANDS)
+    assert param.required is False
+
+
 async def test_ask_api_error(report, ai_cog, mock_ctx):
     expected = "Something broke on my end, dude. Check the bot logs and try again."
     ai_cog.grok.send_message.side_effect = RuntimeError("API down")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slash AI commands were failing after the hybrid migration. Two separate bugs:

1. **FK errors on `/ask`, `/imagine`, `/voice`** — Slash invocations never go through `on_message`, so nothing was inserted into `messages` before `chatgpt_logs` / `dalle_3_prompts` logged with that `message_id`.
2. **`image is a required argument that is missing an attachment`** — Attachment params used `discord.Attachment = None` without `Optional[...]`, so discord.py treated them as required.

## Fix

- Before AI DB logging on slash, upsert a `messages` row (`_ensure_message_row`)
- Mark image options as `Optional[discord.Attachment] = None` and put `prompt` first
- Prefix path unchanged (still relies on existing `on_message` insert)

## Test plan

- [x] `./scripts/test.sh -m "not live"` (78 passed)
- [ ] After deploy: `/ask` with only a prompt works
- [ ] `/ask` with optional image works
- [ ] `/imagine` and `/voice` work
- [ ] `_ask` prefix still works

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6b66-97d1-79c4-9db8-93e8cda69594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6b66-97d1-79c4-9db8-93e8cda69594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

