### PR TITLE
Show slash /ask prompts as in-channel quotes

### DIFF
--- a/cogs/ai.py
+++ b/cogs/ai.py
@@ -65,6 +65,38 @@ async def _ensure_message_row(ctx, content: str = "") -> None:
     await loop.run_in_executor(None, db_ops.update_messages, message_data)
 
 
+def _format_prompt_context(author, prompt: str) -> str:
+    """Blockquote the prompt so slash invocations are visible in-channel."""
+    attribution = f"\n— {author.mention}"
+    max_body = 2000 - len(attribution)
+    body = (prompt or "").strip() or "…"
+    if len(body) > max_body - 2:
+        body = body[: max_body - 5] + "..."
+    quoted = "\n".join(f"> {line}" if line else ">" for line in body.splitlines())
+    return f"{quoted}{attribution}"
+
+
+async def _send_slash_prompt_context(ctx, prompt: str):
+    """Post a visible prompt quote for slash commands; no-op for prefix."""
+    if ctx.interaction is None:
+        return None
+    return await ctx.send(_format_prompt_context(ctx.author, prompt))
+
+
+async def _send_answer(ctx, context_msg, content=None, **kwargs):
+    """Reply to the slash prompt quote when present; otherwise send normally."""
+    if context_msg is not None:
+        if content is not None:
+            await context_msg.reply(content, mention_author=False, **kwargs)
+        else:
+            await context_msg.reply(mention_author=False, **kwargs)
+    else:
+        if content is not None:
+            await ctx.send(content, **kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+
 class AI(commands.Cog):
     """Chat, image generation, and voice."""
 
@@ -156,6 +188,8 @@ class AI(commands.Cog):
             if self._session_turns >= MAX_GROK_SESSION_TURNS:
                 self._reset_session()
 
+            context_msg = await _send_slash_prompt_context(ctx, prompt)
+
             try:
                 await _ensure_message_row(ctx, content=prompt)
                 next_response_id, response_text = self.grok.send_message(
@@ -168,14 +202,22 @@ class AI(commands.Cog):
                 )
             except Exception:
                 logger.exception("/ask failed for user %s", ctx.author.id)
-                await ctx.send("Something broke on my end, dude. Check the bot logs and try again.")
+                await _send_answer(
+                    ctx,
+                    context_msg,
+                    "Something broke on my end, dude. Check the bot logs and try again.",
+                )
                 return
 
             if next_response_id is not None:
                 self.last_response_id = next_response_id
                 self._session_turns += 1
 
-            await ctx.send(response_text or "Sorry, I couldn't generate a reply this time. Please try again.")
+            await _send_answer(
+                ctx,
+                context_msg,
+                response_text or "Sorry, I couldn't generate a reply this time. Please try again.",
+            )
 
     @commands.hybrid_command(brief="Generate an AI image")
     @commands.cooldown(IMAGINE_RATE_LIMIT, IMAGINE_RATE_PERIOD_SECONDS, commands.BucketType.user)
@@ -269,6 +311,7 @@ class AI(commands.Cog):
             return
 
         async with acknowledge(ctx):
+            context_msg = await _send_slash_prompt_context(ctx, prompt)
             try:
                 if self._session_turns >= MAX_GROK_SESSION_TURNS:
                     self._reset_session()
@@ -287,7 +330,11 @@ class AI(commands.Cog):
                     self._session_turns += 1
 
                 if not response_text:
-                    await ctx.send("Sorry, I couldn't generate a spoken response. Please try again.")
+                    await _send_answer(
+                        ctx,
+                        context_msg,
+                        "Sorry, I couldn't generate a spoken response. Please try again.",
+                    )
                     return
 
                 tts_response = requests.post(
@@ -309,14 +356,22 @@ class AI(commands.Cog):
                     filename="voice.mp3"
                 )
 
-                await ctx.send(file=audio_file)
+                await _send_answer(ctx, context_msg, file=audio_file)
 
             except requests.exceptions.RequestException:
                 logger.exception("/voice TTS request failed for user %s", ctx.author.id)
-                await ctx.send("Something broke generating speech. Check the bot logs and try again.")
+                await _send_answer(
+                    ctx,
+                    context_msg,
+                    "Something broke generating speech. Check the bot logs and try again.",
+                )
             except Exception:
                 logger.exception("/voice failed for user %s", ctx.author.id)
-                await ctx.send("Something broke on my end, dude. Check the bot logs and try again.")
+                await _send_answer(
+                    ctx,
+                    context_msg,
+                    "Something broke on my end, dude. Check the bot logs and try again.",
+                )
 
 
 async def setup(bot):

--- a/cogs/ai.py
+++ b/cogs/ai.py
@@ -46,6 +46,25 @@ def _collect_image_urls(ctx, *attachments: Optional[discord.Attachment]) -> List
     return _image_urls_from_message(ctx)
 
 
+async def _ensure_message_row(ctx, content: str = "") -> None:
+    """Insert a messages row for slash invocations (they skip on_message).
+
+    AI logging FKs chatgpt_logs / dalle_3_prompts.message_id → messages.id.
+    Prefix commands are already stored in on_message before process_commands.
+    """
+    if ctx.interaction is None:
+        return
+    message_data = (
+        ctx.message.id,
+        ctx.author.id,
+        ctx.channel.id,
+        content or (getattr(ctx.message, "content", None) or ""),
+        ctx.message.created_at,
+    )
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, db_ops.update_messages, message_data)
+
+
 class AI(commands.Cog):
     """Chat, image generation, and voice."""
 
@@ -121,7 +140,13 @@ class AI(commands.Cog):
         prompt="Your question or message",
         image="Optional image to include with your question",
     )
-    async def ask(self, ctx, image: discord.Attachment = None, *, prompt: str):
+    async def ask(
+        self,
+        ctx,
+        *,
+        prompt: str,
+        image: Optional[discord.Attachment] = None,
+    ):
         """Ask a question. You can also attach images."""
 
         image_urls = _collect_image_urls(ctx, image)
@@ -132,6 +157,7 @@ class AI(commands.Cog):
                 self._reset_session()
 
             try:
+                await _ensure_message_row(ctx, content=prompt)
                 next_response_id, response_text = self.grok.send_message(
                     prompt,
                     previous_response_id=self.last_response_id,
@@ -162,19 +188,17 @@ class AI(commands.Cog):
     async def imagine(
         self,
         ctx,
-        image1: discord.Attachment = None,
-        image2: discord.Attachment = None,
-        image3: discord.Attachment = None,
         *,
         prompt: str,
+        image1: Optional[discord.Attachment] = None,
+        image2: Optional[discord.Attachment] = None,
+        image3: Optional[discord.Attachment] = None,
     ):
         """Generate an AI image based on a prompt and optional input images.
 
         Attach up to 3 images to edit or combine them; refer to them in the prompt
         as <IMAGE_0>, <IMAGE_1>, <IMAGE_2> (attachment order).
         """
-
-        db_ops.write_dalle_entry(user_id=ctx.author.id, prompt=prompt, message_id=ctx.message.id)
 
         input_image_urls = _collect_image_urls(ctx, image1, image2, image3)
         if len(input_image_urls) > MAX_IMAGINE_INPUT_IMAGES:
@@ -184,6 +208,9 @@ class AI(commands.Cog):
             return
 
         async with acknowledge(ctx):
+            await _ensure_message_row(ctx, content=prompt)
+            db_ops.write_dalle_entry(user_id=ctx.author.id, prompt=prompt, message_id=ctx.message.id)
+
             response = call_grok_imagine(
                 prompt,
                 input_image_urls=input_image_urls or None,
@@ -246,6 +273,7 @@ class AI(commands.Cog):
                 if self._session_turns >= MAX_GROK_SESSION_TURNS:
                     self._reset_session()
 
+                await _ensure_message_row(ctx, content=prompt)
                 next_response_id, response_text = self.grok.send_message(
                     prompt,
                     previous_response_id=self.last_response_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,7 @@ def mock_db_ops(request):
         patch.object(db_ops, "update_members", MagicMock()),
         patch.object(db_ops, "update_emojis", MagicMock()),
         patch.object(db_ops, "update_channels", MagicMock()),
+        patch.object(db_ops, "update_messages", MagicMock()),
         patch.object(db_ops, "log_chatgpt_interaction", MagicMock()),
         patch.object(db_ops, "get_dink_balance", MagicMock(return_value=0.0)),
         patch.object(db_ops, "get_dink_ledger", MagicMock()),

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -37,6 +37,41 @@ async def test_ask_success(report, ai_cog, mock_ctx):
     assert ai_cog._session_turns == 1
 
 
+async def test_ask_slash_inserts_message_row(report, mock_db_ops, ai_cog, mock_ctx):
+    """Slash skips on_message; AI logging FKs message_id → messages.id."""
+    from datetime import datetime, timezone
+
+    mock_ctx.interaction = MagicMock()
+    mock_ctx.message.created_at = datetime(2024, 6, 11, tzinfo=timezone.utc)
+    ai_cog.grok.send_message.return_value = ("new-id", "ok")
+
+    await ai_cog.ask.callback(ai_cog, mock_ctx, prompt="hello slash")
+
+    mock_db_ops.update_messages.assert_called_once()
+    row = mock_db_ops.update_messages.call_args.args[0]
+    report.record("message id logged", mock_ctx.message.id, row[0], section=SECTION_COMMANDS)
+    report.record("message content", "hello slash", row[3], section=SECTION_COMMANDS)
+    assert row[0] == mock_ctx.message.id
+    assert row[3] == "hello slash"
+    ai_cog.grok.send_message.assert_called_once()
+
+
+async def test_ask_prefix_skips_message_insert(report, mock_db_ops, ai_cog, mock_ctx):
+    mock_ctx.interaction = None
+    ai_cog.grok.send_message.return_value = ("new-id", "ok")
+
+    await ai_cog.ask.callback(ai_cog, mock_ctx, prompt="hello prefix")
+
+    mock_db_ops.update_messages.assert_not_called()
+    report.record("prefix message insert", "skipped", "skipped", section=SECTION_COMMANDS)
+
+
+def test_ask_image_option_is_optional(report, ai_cog):
+    param = ai_cog.ask.clean_params["image"]
+    report.record("image required", False, param.required, section=SECTION_COMMANDS)
+    assert param.required is False
+
+
 async def test_ask_api_error(report, ai_cog, mock_ctx):
     expected = "Something broke on my end, dude. Check the bot logs and try again."
     ai_cog.grok.send_message.side_effect = RuntimeError("API down")

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -43,6 +43,9 @@ async def test_ask_slash_inserts_message_row(report, mock_db_ops, ai_cog, mock_c
 
     mock_ctx.interaction = MagicMock()
     mock_ctx.message.created_at = datetime(2024, 6, 11, tzinfo=timezone.utc)
+    context_msg = AsyncMock()
+    context_msg.reply = AsyncMock()
+    mock_ctx.send = AsyncMock(return_value=context_msg)
     ai_cog.grok.send_message.return_value = ("new-id", "ok")
 
     await ai_cog.ask.callback(ai_cog, mock_ctx, prompt="hello slash")
@@ -56,6 +59,31 @@ async def test_ask_slash_inserts_message_row(report, mock_db_ops, ai_cog, mock_c
     ai_cog.grok.send_message.assert_called_once()
 
 
+async def test_ask_slash_quotes_prompt_then_replies(report, mock_db_ops, ai_cog, mock_ctx):
+    from datetime import datetime, timezone
+
+    mock_ctx.interaction = MagicMock()
+    mock_ctx.message.created_at = datetime(2024, 6, 11, tzinfo=timezone.utc)
+    context_msg = AsyncMock()
+    context_msg.reply = AsyncMock()
+    mock_ctx.send = AsyncMock(return_value=context_msg)
+    ai_cog.grok.send_message.return_value = ("new-id", "answer only")
+
+    await ai_cog.ask.callback(ai_cog, mock_ctx, prompt="what is juice?")
+
+    context_text = mock_ctx.send.call_args.args[0]
+    report.record("context has prompt", True, "what is juice?" in context_text, section=SECTION_COMMANDS)
+    report.record("context is quote", True, context_text.startswith(">"), section=SECTION_COMMANDS)
+    report.record("answer via reply", "answer only", context_msg.reply.call_args.args[0], section=SECTION_COMMANDS)
+
+    assert "what is juice?" in context_text
+    assert context_text.startswith(">")
+    assert mock_ctx.author.mention in context_text
+    context_msg.reply.assert_awaited_once_with("answer only", mention_author=False)
+    # Answer must not restate the prompt
+    assert context_msg.reply.call_args.args[0] == "answer only"
+
+
 async def test_ask_prefix_skips_message_insert(report, mock_db_ops, ai_cog, mock_ctx):
     mock_ctx.interaction = None
     ai_cog.grok.send_message.return_value = ("new-id", "ok")
@@ -64,6 +92,16 @@ async def test_ask_prefix_skips_message_insert(report, mock_db_ops, ai_cog, mock
 
     mock_db_ops.update_messages.assert_not_called()
     report.record("prefix message insert", "skipped", "skipped", section=SECTION_COMMANDS)
+
+
+def test_format_prompt_context_quotes_and_attributes(report, mock_author):
+    from cogs.ai import _format_prompt_context
+
+    text = _format_prompt_context(mock_author, "line one\nline two")
+    report.record("format starts with quote", True, text.startswith("> line one"), section=SECTION_COMMANDS)
+    assert "> line one" in text
+    assert "> line two" in text
+    assert mock_author.mention in text
 
 
 def test_ask_image_option_is_optional(report, ai_cog):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slash `/ask` only shows “User used /ask”, so other people can’t see the question. This posts a short **blockquote of the prompt**, then **replies with only the answer** (no prompt echoed in the reply).

Same pattern for `/voice` (quote, then audio reply). Prefix `_ask` / `_voice` unchanged — the user’s message already has the prompt.

## Also includes

The AI slash FK / optional-image fix from #21 (this branch is based on it). You can merge **this PR alone** and close #21, or merge #21 first then this.

## Behavior

1. User runs `/ask prompt: what is juice?`
2. Bot posts:
   ```
   > what is juice?
   — @user
   ```
3. Bot replies to that message with just the answer

## Test plan

- [x] `./scripts/test.sh -m "not live"` (80 passed)
- [ ] After deploy: `/ask` shows a quote, then an answer-only reply
- [ ] Answer does not restate the prompt
- [ ] `_ask` still just replies once (no extra quote)
- [ ] `/voice` quotes the prompt, then replies with audio

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6b66-97d1-79c4-9db8-93e8cda69594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6b66-97d1-79c4-9db8-93e8cda69594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

