### PR TITLE
Add dinkscord.com dashboard link and first-win promo

### DIFF
--- a/cogs/first.py
+++ b/cogs/first.py
@@ -9,8 +9,15 @@ import matplotlib.pyplot as plt
 from datetime import datetime
 import pytz
 from utils.db import db_ops, streak_calc, juice_calc
-from utils.constants import GENERAL_CHANNEL_ID, EMBED_COLOR, DINK_MINT_AMOUNT
+from utils.constants import (
+    GENERAL_CHANNEL_ID,
+    EMBED_COLOR,
+    DINK_MINT_AMOUNT,
+    DINKSCORD_URL,
+    PROMOTE_DINKSCORD_ON_FIRST,
+)
 from utils.interactions import acknowledge
+from utils.views import dinkscord_link_view
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +56,14 @@ class First(commands.Cog):
                 await asyncio.sleep(0.5)
                 Author = ctx.author.mention
                 msg = f"{Author} is first today! 🥳 +{DINK_MINT_AMOUNT:g} **DINK**"
-                await ctx.send(msg)
+                if PROMOTE_DINKSCORD_ON_FIRST:
+                    msg += (
+                        f"\nCheck out the recently launched website for Peter Dinklage: "
+                        f"{DINKSCORD_URL}"
+                    )
+                    await ctx.send(msg, view=dinkscord_link_view())
+                else:
+                    await ctx.send(msg)
 
     @commands.hybrid_command(brief='Show the firsts leaderboard')
     async def score(self, ctx):

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1,10 +1,13 @@
 from discord import app_commands
 from discord.ext import commands
+from utils.constants import DINKSCORD_URL
+from utils.views import dinkscord_link_view
+
 
 
 class Utility(commands.Cog):
     """Simple utility commands."""
-    
+
     def __init__(self, bot):
         self.bot = bot
 
@@ -25,6 +28,15 @@ class Utility(commands.Cog):
     async def simonsays(self, ctx, *, message: str):
         """Make the bot repeat your message."""
         await ctx.send(message)
+
+    @commands.hybrid_command(brief='Link to the Dinkscord dashboard')
+    async def dashboard(self, ctx):
+        """Share a link button to the public Dinkscord dashboard."""
+        await ctx.send(
+            f"Check out the Dinkscord dashboard: {DINKSCORD_URL}",
+            view=dinkscord_link_view(),
+        )
+
 
 async def setup(bot):
     await bot.add_cog(Utility(bot))

--- a/docs/self_knowledge/first_game.md
+++ b/docs/self_knowledge/first_game.md
@@ -8,6 +8,8 @@ The most popular game on the server: be the first person to claim the day.
   tell you to go to #general.
 - Only **one person** wins each day. A new day starts at **midnight US/Eastern**.
 - If you win, the bot announces it and you earn **1 DINK** (see the `dinkcoin` topic).
+  For now the win message also promotes the recently launched site at
+  https://dinkscord.com with a link button.
 - If someone already claimed today, the bot says first has been taken — try again
   tomorrow.
 

--- a/docs/self_knowledge/overview.md
+++ b/docs/self_knowledge/overview.md
@@ -15,10 +15,10 @@ older `_` prefix still works. Commands are case-insensitive.
   you attach), `/imagine` for AI art, `/voice` for a spoken reply, and `/clear`
   to start a fresh chat. See the `ai_features` topic.
 - **Server stats** — you keep track of activity on the server and post a monthly
-  report. Stats are also on the public dashboard at
-  https://peterdinklage.streamlit.app/. See the `server_stats` topic.
-- **Fun & utilities** — `/ping`, `/hello`, `/simonsays`, and `/donation` (a thank-you
-  list of patrons who help keep the bot running).
+  report. Stats are also on the public dashboard at https://dinkscord.com
+  (`/dashboard` shares a link). See the `server_stats` topic.
+- **Fun & utilities** — `/ping`, `/hello`, `/simonsays`, `/dashboard`, and
+  `/donation` (a thank-you list of patrons who help keep the bot running).
 
 ## How to talk about yourself
 

--- a/docs/self_knowledge/server_stats.md
+++ b/docs/self_knowledge/server_stats.md
@@ -15,8 +15,8 @@ leaderboards, graphs, and the monthly report — not through raw data.
 
 - **Monthly report** — on the 1st of each month at 9am Eastern, you post a summary
   in #general ranking the top messengers from the previous month.
-- **Dashboard** — https://peterdinklage.streamlit.app/ shows server trends like
-  message counts and first-game stats over time.
+- **Dashboard** — https://dinkscord.com shows server trends like message counts
+  and first-game stats over time. Members can get a link with `/dashboard`.
 
 ## If someone asks "does the bot log everything?"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ EXPECTED_COMMANDS = frozenset({
     "balance", "ledger", "pay",
     "ask", "imagine", "clear", "voice",
     "members", "emojis", "channels",
-    "hello", "ping", "simonsays",
+    "hello", "ping", "simonsays", "dashboard",
     "donation",
 })
 

--- a/tests/test_bot_loading.py
+++ b/tests/test_bot_loading.py
@@ -44,4 +44,4 @@ def test_all_commands_registered(report):
     )
     report.record("command count", len(EXPECTED_COMMANDS), len(registered), section=SECTION_WIRING)
     assert EXPECTED_COMMANDS <= registered
-    assert len(EXPECTED_COMMANDS) == 20
+    assert len(EXPECTED_COMMANDS) == 21

--- a/tests/test_first_commands.py
+++ b/tests/test_first_commands.py
@@ -8,7 +8,14 @@ import pytz
 
 from cogs.first import First
 from tests.reporting import SECTION_COMMANDS
-from utils.constants import GENERAL_CHANNEL_ID
+from utils.constants import DINKSCORD_URL, GENERAL_CHANNEL_ID
+
+
+def _expected_first_win(mention: str) -> str:
+    return (
+        f"{mention} is first today! 🥳 +1 **DINK**\n"
+        f"Check out the recently launched website for Peter Dinklage: {DINKSCORD_URL}"
+    )
 
 
 def _est_today_df(date_str: str, user_id: str = "999") -> pd.DataFrame:
@@ -39,7 +46,7 @@ async def test_first_wrong_channel(report, mock_bot, mock_ctx):
 async def test_first_successful_claim(
     mock_datetime, _mock_sleep, report, mock_db_ops, mock_bot, mock_ctx,
 ):
-    expected = f"{mock_ctx.author.mention} is first today! 🥳 +1 **DINK**"
+    expected = _expected_first_win(mock_ctx.author.mention)
     est = pytz.timezone("US/Eastern")
     today = est.localize(datetime(2024, 6, 11, 8, 0, 0))
 
@@ -55,7 +62,9 @@ async def test_first_successful_claim(
 
     mock_db_ops.write_first_entry.assert_called_once_with(mock_ctx.author.id)
     mock_db_ops.record_dink_mint.assert_called_once_with(mock_ctx.author.id, 1.0)
-    mock_ctx.send.assert_awaited_once_with(expected)
+    mock_ctx.send.assert_awaited_once()
+    assert actual == expected
+    assert mock_ctx.send.call_args.kwargs.get("view") is not None
 
 
 @patch("cogs.first.datetime")
@@ -143,7 +152,7 @@ async def test_juice(report, mock_db_ops, mock_bot, mock_ctx, leaderboard_first_
 async def test_first_empty_table_allows_claim(
     mock_datetime, _mock_sleep, report, mock_db_ops, mock_bot, mock_ctx, empty_first_df,
 ):
-    expected = f"{mock_ctx.author.mention} is first today! 🥳 +1 **DINK**"
+    expected = _expected_first_win(mock_ctx.author.mention)
     est = pytz.timezone("US/Eastern")
     today = est.localize(datetime(2024, 6, 11, 8, 0, 0))
 
@@ -159,7 +168,9 @@ async def test_first_empty_table_allows_claim(
 
     mock_db_ops.write_first_entry.assert_called_once_with(mock_ctx.author.id)
     mock_db_ops.record_dink_mint.assert_called_once_with(mock_ctx.author.id, 1.0)
-    mock_ctx.send.assert_awaited_once_with(expected)
+    mock_ctx.send.assert_awaited_once()
+    assert actual == expected
+    assert mock_ctx.send.call_args.kwargs.get("view") is not None
 
 
 async def test_score_empty(report, mock_db_ops, mock_bot, mock_ctx, empty_first_df):

--- a/tests/test_utility_commands.py
+++ b/tests/test_utility_commands.py
@@ -2,6 +2,7 @@
 
 from cogs.utility import Utility
 from tests.reporting import SECTION_COMMANDS
+from utils.constants import DINKSCORD_URL
 
 
 async def test_hello(report, mock_bot, mock_ctx):
@@ -29,3 +30,14 @@ async def test_simonsays(report, mock_bot, mock_ctx):
     actual = mock_ctx.send.call_args.args[0]
     report.record("ctx.send", expected, actual, section=SECTION_COMMANDS)
     mock_ctx.send.assert_awaited_once_with(expected)
+
+
+async def test_dashboard(report, mock_bot, mock_ctx):
+    expected = f"Check out the Dinkscord dashboard: {DINKSCORD_URL}"
+    cog = Utility(mock_bot)
+    await cog.dashboard.callback(cog, mock_ctx)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("ctx.send", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.send.assert_awaited_once()
+    assert actual == expected
+    assert mock_ctx.send.call_args.kwargs.get("view") is not None

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -26,3 +26,9 @@ IMAGINE_RATE_PERIOD_SECONDS = 3600
 
 # DINK awarded for each successful /1st claim (MySQL ledger only)
 DINK_MINT_AMOUNT = float(os.getenv("DINK_MINT_AMOUNT", "1"))
+
+# Public Dinkscord dashboard
+DINKSCORD_URL = "https://dinkscord.com"
+
+# Temporary: append site promo + link button on successful /1st claims
+PROMOTE_DINKSCORD_ON_FIRST = True

--- a/utils/views.py
+++ b/utils/views.py
@@ -1,0 +1,17 @@
+"""Reusable Discord UI components."""
+
+import discord
+from utils.constants import DINKSCORD_URL
+
+
+def dinkscord_link_view(label: str = "Visit dinkscord.com") -> discord.ui.View:
+    """Return a view with a single link button to the public dashboard."""
+    view = discord.ui.View()
+    view.add_item(
+        discord.ui.Button(
+            label=label,
+            style=discord.ButtonStyle.link,
+            url=DINKSCORD_URL,
+        )
+    )
+    return view


### PR DESCRIPTION
## Summary
- Add hybrid `/dashboard` (and `_dashboard`) that posts a link button to https://dinkscord.com
- Temporarily promote the new site on successful `/1st` wins with copy + the same link button (`PROMOTE_DINKSCORD_ON_FIRST` to turn off later)
- Point self-knowledge docs at dinkscord.com instead of the old Streamlit URL

## Test plan
- [ ] Run `/dashboard` or `_dashboard` and confirm the Visit dinkscord.com button opens https://dinkscord.com
- [ ] Claim `/1st` in #general and confirm the win message includes the site promo and button
- [ ] Confirm already-claimed `/1st` replies are unchanged
- [ ] After review, set `PROMOTE_DINKSCORD_ON_FIRST = False` when the temporary promo should end