### PR TITLE
Make /dashboard button-only

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1,8 +1,6 @@
 from discord import app_commands
 from discord.ext import commands
-from utils.constants import DINKSCORD_URL
 from utils.views import dinkscord_link_view
-
 
 
 class Utility(commands.Cog):
@@ -32,10 +30,8 @@ class Utility(commands.Cog):
     @commands.hybrid_command(brief='Link to the Dinkscord dashboard')
     async def dashboard(self, ctx):
         """Share a link button to the public Dinkscord dashboard."""
-        await ctx.send(
-            f"Check out the Dinkscord dashboard: {DINKSCORD_URL}",
-            view=dinkscord_link_view(),
-        )
+        # Discord requires message content; zero-width space keeps it button-only.
+        await ctx.send("\u200b", view=dinkscord_link_view())
 
 
 async def setup(bot):

--- a/tests/test_utility_commands.py
+++ b/tests/test_utility_commands.py
@@ -2,7 +2,6 @@
 
 from cogs.utility import Utility
 from tests.reporting import SECTION_COMMANDS
-from utils.constants import DINKSCORD_URL
 
 
 async def test_hello(report, mock_bot, mock_ctx):
@@ -33,7 +32,7 @@ async def test_simonsays(report, mock_bot, mock_ctx):
 
 
 async def test_dashboard(report, mock_bot, mock_ctx):
-    expected = f"Check out the Dinkscord dashboard: {DINKSCORD_URL}"
+    expected = "\u200b"
     cog = Utility(mock_bot)
     await cog.dashboard.callback(cog, mock_ctx)
     actual = mock_ctx.send.call_args.args[0]


### PR DESCRIPTION
## Summary
- Update `/dashboard` to post only the Visit dinkscord.com link button
- Use a zero-width space for Discord message content so no caption text appears
- Adjust the utility command test accordingly

## Test plan
- [ ] Run `/dashboard` or `_dashboard` and confirm only the link button appears (no caption text)
- [ ] Confirm the button still opens https://dinkscord.com
- [ ] Confirm first-win promo behavior is unchanged