### PR TITLE
Simplify /1st promo copy and slash /ask replies

### DIFF
--- a/cogs/ai.py
+++ b/cogs/ai.py
@@ -66,7 +66,7 @@ async def _ensure_message_row(ctx, content: str = "") -> None:
 
 
 def _format_prompt_context(author, prompt: str) -> str:
-    """Blockquote the prompt so slash invocations are visible in-channel."""
+    """Blockquote the prompt so slash /voice invocations are visible in-channel."""
     attribution = f"\n— {author.mention}"
     max_body = 2000 - len(attribution)
     body = (prompt or "").strip() or "…"
@@ -76,15 +76,33 @@ def _format_prompt_context(author, prompt: str) -> str:
     return f"{quoted}{attribution}"
 
 
+def _format_slash_ask_message(author, prompt: str, response: str) -> str:
+    """Format slash /ask as '@user: prompt\\n\\nresponse' (Discord 2000-char limit)."""
+    header = f"{author.mention}: "
+    sep = "\n\n"
+    prompt_body = (prompt or "").strip() or "…"
+    answer = (response or "").strip() or "…"
+    available = 2000 - len(header) - len(sep)
+    if len(prompt_body) + len(answer) > available:
+        # Prefer keeping the answer; trim the prompt first, then the answer.
+        max_prompt = min(len(prompt_body), max(32, available // 3))
+        if len(prompt_body) > max_prompt:
+            prompt_body = prompt_body[: max_prompt - 3] + "..."
+        max_answer = available - len(prompt_body)
+        if len(answer) > max_answer:
+            answer = answer[: max_answer - 3] + "..."
+    return f"{header}{prompt_body}{sep}{answer}"
+
+
 async def _send_slash_prompt_context(ctx, prompt: str):
-    """Post a visible prompt quote for slash commands; no-op for prefix."""
+    """Post a visible prompt quote for slash /voice; no-op for prefix."""
     if ctx.interaction is None:
         return None
     return await ctx.send(_format_prompt_context(ctx.author, prompt))
 
 
 async def _send_answer(ctx, context_msg, content=None, **kwargs):
-    """Reply to the slash prompt quote when present; otherwise send normally."""
+    """Reply to the slash /voice prompt quote when present; otherwise send normally."""
     if context_msg is not None:
         if content is not None:
             await context_msg.reply(content, mention_author=False, **kwargs)
@@ -95,6 +113,14 @@ async def _send_answer(ctx, context_msg, content=None, **kwargs):
             await ctx.send(content, **kwargs)
         else:
             await ctx.send(**kwargs)
+
+
+async def _send_ask_answer(ctx, prompt: str, content: str):
+    """Send /ask answer; slash includes '@user: prompt' in one message."""
+    if ctx.interaction is not None:
+        await ctx.send(_format_slash_ask_message(ctx.author, prompt, content))
+    else:
+        await ctx.send(content)
 
 
 class AI(commands.Cog):
@@ -188,8 +214,6 @@ class AI(commands.Cog):
             if self._session_turns >= MAX_GROK_SESSION_TURNS:
                 self._reset_session()
 
-            context_msg = await _send_slash_prompt_context(ctx, prompt)
-
             try:
                 await _ensure_message_row(ctx, content=prompt)
                 next_response_id, response_text = self.grok.send_message(
@@ -202,9 +226,9 @@ class AI(commands.Cog):
                 )
             except Exception:
                 logger.exception("/ask failed for user %s", ctx.author.id)
-                await _send_answer(
+                await _send_ask_answer(
                     ctx,
-                    context_msg,
+                    prompt,
                     "Something broke on my end, dude. Check the bot logs and try again.",
                 )
                 return
@@ -213,9 +237,9 @@ class AI(commands.Cog):
                 self.last_response_id = next_response_id
                 self._session_turns += 1
 
-            await _send_answer(
+            await _send_ask_answer(
                 ctx,
-                context_msg,
+                prompt,
                 response_text or "Sorry, I couldn't generate a reply this time. Please try again.",
             )
 

--- a/cogs/first.py
+++ b/cogs/first.py
@@ -13,7 +13,6 @@ from utils.constants import (
     GENERAL_CHANNEL_ID,
     EMBED_COLOR,
     DINK_MINT_AMOUNT,
-    DINKSCORD_URL,
     PROMOTE_DINKSCORD_ON_FIRST,
 )
 from utils.interactions import acknowledge
@@ -57,10 +56,7 @@ class First(commands.Cog):
                 Author = ctx.author.mention
                 msg = f"{Author} is first today! 🥳 +{DINK_MINT_AMOUNT:g} **DINK**"
                 if PROMOTE_DINKSCORD_ON_FIRST:
-                    msg += (
-                        f"\nCheck out the recently launched website for Peter Dinklage: "
-                        f"{DINKSCORD_URL}"
-                    )
+                    msg += "\nCheck out the new Dinkscord website"
                     await ctx.send(msg, view=dinkscord_link_view())
                 else:
                     await ctx.send(msg)

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -43,9 +43,7 @@ async def test_ask_slash_inserts_message_row(report, mock_db_ops, ai_cog, mock_c
 
     mock_ctx.interaction = MagicMock()
     mock_ctx.message.created_at = datetime(2024, 6, 11, tzinfo=timezone.utc)
-    context_msg = AsyncMock()
-    context_msg.reply = AsyncMock()
-    mock_ctx.send = AsyncMock(return_value=context_msg)
+    mock_ctx.send = AsyncMock()
     ai_cog.grok.send_message.return_value = ("new-id", "ok")
 
     await ai_cog.ask.callback(ai_cog, mock_ctx, prompt="hello slash")
@@ -59,29 +57,20 @@ async def test_ask_slash_inserts_message_row(report, mock_db_ops, ai_cog, mock_c
     ai_cog.grok.send_message.assert_called_once()
 
 
-async def test_ask_slash_quotes_prompt_then_replies(report, mock_db_ops, ai_cog, mock_ctx):
+async def test_ask_slash_single_message_with_prompt(report, mock_db_ops, ai_cog, mock_ctx):
     from datetime import datetime, timezone
 
     mock_ctx.interaction = MagicMock()
     mock_ctx.message.created_at = datetime(2024, 6, 11, tzinfo=timezone.utc)
-    context_msg = AsyncMock()
-    context_msg.reply = AsyncMock()
-    mock_ctx.send = AsyncMock(return_value=context_msg)
+    mock_ctx.send = AsyncMock()
     ai_cog.grok.send_message.return_value = ("new-id", "answer only")
 
     await ai_cog.ask.callback(ai_cog, mock_ctx, prompt="what is juice?")
 
-    context_text = mock_ctx.send.call_args.args[0]
-    report.record("context has prompt", True, "what is juice?" in context_text, section=SECTION_COMMANDS)
-    report.record("context is quote", True, context_text.startswith(">"), section=SECTION_COMMANDS)
-    report.record("answer via reply", "answer only", context_msg.reply.call_args.args[0], section=SECTION_COMMANDS)
-
-    assert "what is juice?" in context_text
-    assert context_text.startswith(">")
-    assert mock_ctx.author.mention in context_text
-    context_msg.reply.assert_awaited_once_with("answer only", mention_author=False)
-    # Answer must not restate the prompt
-    assert context_msg.reply.call_args.args[0] == "answer only"
+    expected = f"{mock_ctx.author.mention}: what is juice?\n\nanswer only"
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("slash ask message", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.send.assert_awaited_once_with(expected)
 
 
 async def test_ask_prefix_skips_message_insert(report, mock_db_ops, ai_cog, mock_ctx):
@@ -102,6 +91,16 @@ def test_format_prompt_context_quotes_and_attributes(report, mock_author):
     assert "> line one" in text
     assert "> line two" in text
     assert mock_author.mention in text
+
+
+def test_format_slash_ask_message(report, mock_author):
+    from cogs.ai import _format_slash_ask_message
+
+    text = _format_slash_ask_message(mock_author, "what is juice?", "minutes to midnight")
+    expected = f"{mock_author.mention}: what is juice?\n\nminutes to midnight"
+    report.record("slash ask format", expected, text, section=SECTION_COMMANDS)
+    assert text == expected
+    assert len(text) <= 2000
 
 
 def test_ask_image_option_is_optional(report, ai_cog):

--- a/tests/test_first_commands.py
+++ b/tests/test_first_commands.py
@@ -8,13 +8,13 @@ import pytz
 
 from cogs.first import First
 from tests.reporting import SECTION_COMMANDS
-from utils.constants import DINKSCORD_URL, GENERAL_CHANNEL_ID
+from utils.constants import GENERAL_CHANNEL_ID
 
 
 def _expected_first_win(mention: str) -> str:
     return (
         f"{mention} is first today! 🥳 +1 **DINK**\n"
-        f"Check out the recently launched website for Peter Dinklage: {DINKSCORD_URL}"
+        "Check out the new Dinkscord website"
     )
 
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -30,5 +30,5 @@ DINK_MINT_AMOUNT = float(os.getenv("DINK_MINT_AMOUNT", "1"))
 # Public Dinkscord dashboard
 DINKSCORD_URL = "https://dinkscord.com"
 
-# Temporary: append site promo + link button on successful /1st claims
+# Temporary: append site promo text + link button on successful /1st claims
 PROMOTE_DINKSCORD_ON_FIRST = True


### PR DESCRIPTION
## Summary
- Remove the inline URL from successful `/1st` promo text ("Check out the new Dinkscord website"); keep the link button only.
- Change slash `/ask` to a single message: `@user: prompt` then a blank line and the AI reply (no quote + threaded reply).
- Prefix `_ask` and `/voice` behavior unchanged.

## Test plan
- [x] Local pytest (excluding graph/live): 79 passed
- [ ] CI checks green
- [ ] `/1st` win shows new promo text + Visit dinkscord.com button, no URL in message body
- [ ] Slash `/ask` posts one message as `@user: prompt\n\nanswer`
- [ ] Prefix `_ask` still posts answer only