### PR TITLE
Add /request command for DINK peer transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Successful `/1st` claims award **1 DINK** (configurable via `DINK_MINT_AMOUNT`).
 | `/balance` | Show your DINK balance |
 | `/ledger` | Top holders leaderboard |
 | `/pay` | Send DINK to another user |
+| `/request` | Ask another user for DINK (Accept / Decline) |
 
 Setup: run `scripts/dinkcoin_schema.sql` against your MySQL database once.
 

--- a/cogs/dinkcoin.py
+++ b/cogs/dinkcoin.py
@@ -9,6 +9,101 @@ from utils.db import DatabaseError, db_ops
 
 logger = logging.getLogger(__name__)
 
+REQUEST_TIMEOUT_SECONDS = 300
+
+
+class DinkRequestView(discord.ui.View):
+    """Accept/decline buttons for a pending DINK request."""
+
+    def __init__(self, requester: discord.abc.User, payer: discord.abc.User, amount: int):
+        super().__init__(timeout=REQUEST_TIMEOUT_SECONDS)
+        self.requester_id = requester.id
+        self.payer_id = payer.id
+        self.amount = amount
+        self.requester_mention = requester.mention
+        self.payer_mention = payer.mention
+        self.message: discord.Message | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.payer_id:
+            await interaction.response.send_message(
+                "Only the requested user can respond to this.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    def _disable_buttons(self) -> None:
+        for item in self.children:
+            if isinstance(item, discord.ui.Button):
+                item.disabled = True
+
+    async def on_timeout(self) -> None:
+        self._disable_buttons()
+        if self.message is not None:
+            try:
+                await self.message.edit(
+                    content=(
+                        f"Request expired: {self.requester_mention} asked "
+                        f"{self.payer_mention} for **{self.amount:g} DINK**."
+                    ),
+                    view=self,
+                )
+            except discord.HTTPException:
+                logger.exception("Failed to edit expired DINK request message")
+
+    @discord.ui.button(label="Accept", style=discord.ButtonStyle.success)
+    async def accept(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
+        balance = db_ops.get_dink_balance(self.payer_id)
+        if self.amount > balance:
+            await interaction.response.send_message(
+                f"Insufficient balance. You have **{balance:g} DINK**.",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            db_ops.record_dink_transfer(self.payer_id, self.requester_id, self.amount)
+        except DatabaseError:
+            await interaction.response.send_message(
+                "Transfer failed. Please try again later.",
+                ephemeral=True,
+            )
+            return
+        except Exception as exc:
+            logger.exception("DinkCoin request transfer failed: %s", exc)
+            await interaction.response.send_message(
+                "Transfer failed. Please try again later.",
+                ephemeral=True,
+            )
+            return
+
+        self._disable_buttons()
+        await interaction.response.edit_message(
+            content=(
+                f"{self.payer_mention} accepted and sent **{self.amount:g} DINK** "
+                f"to {self.requester_mention}!"
+            ),
+            view=self,
+        )
+        self.stop()
+
+    @discord.ui.button(label="Decline", style=discord.ButtonStyle.danger)
+    async def decline(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
+        self._disable_buttons()
+        await interaction.response.edit_message(
+            content=(
+                f"{self.payer_mention} declined {self.requester_mention}'s request "
+                f"for **{self.amount:g} DINK**."
+            ),
+            view=self,
+        )
+        self.stop()
+
 
 class DinkCoin(commands.Cog):
     """DinkCoin balances and transfers."""
@@ -96,6 +191,35 @@ class DinkCoin(commands.Cog):
         except Exception as exc:
             logger.exception("DinkCoin transfer failed: %s", exc)
             await ctx.send("Transfer failed. Please try again later.")
+
+    @commands.hybrid_command(brief="Request DINK from another user")
+    @app_commands.describe(
+        member="Who to request DINK from",
+        amount="Whole number of DINK to request",
+    )
+    async def request(self, ctx, member: discord.Member, amount: float):
+        """Ask another user to send you DINK; they can accept or decline."""
+        if member.bot:
+            await ctx.send("You cannot request DINK from bots.")
+            return
+        if member.id == ctx.author.id:
+            await ctx.send("You cannot request DINK from yourself.")
+            return
+        if amount <= 0:
+            await ctx.send("Amount must be greater than zero.")
+            return
+        if amount != int(amount):
+            await ctx.send("Only whole DINK coins can be transferred.")
+            return
+
+        amount = int(amount)
+        view = DinkRequestView(ctx.author, member, amount)
+        message = await ctx.send(
+            f"{member.mention}, {ctx.author.mention} is requesting "
+            f"**{amount:g} DINK**. Accept or decline?",
+            view=view,
+        )
+        view.message = message
 
 
 async def setup(bot):

--- a/docs/self_knowledge/dinkcoin.md
+++ b/docs/self_knowledge/dinkcoin.md
@@ -15,12 +15,16 @@ on any blockchain or crypto wallet.
 - `/balance` — see how much DINK you have.
 - `/ledger` — see who holds the most DINK on the server (top 10 by default, up to 20).
 - `/pay` — send DINK to another member (pick the user and amount).
+- `/request` — ask another member to send you DINK; they get **Accept** and
+  **Decline** buttons.
 
-## Rules for paying
+## Rules for paying and requesting
 
 - Only **whole numbers** of DINK (no decimals).
-- You can't pay yourself or bots.
+- You can't pay/request yourself or bots.
 - You can't send more than you have — the bot will tell you your balance if you try.
+- Only the person being asked can press Accept or Decline on a `/request`.
+- Pending requests expire after a few minutes if nobody responds.
 
 ## Commands
 
@@ -29,3 +33,4 @@ on any blockchain or crypto wallet.
 | `/balance` | Your DINK balance |
 | `/ledger [limit]` | Top holders + total DINK on the server |
 | `/pay` | Send DINK to someone |
+| `/request` | Ask someone for DINK (Accept / Decline buttons) |

--- a/docs/self_knowledge/overview.md
+++ b/docs/self_knowledge/overview.md
@@ -9,8 +9,8 @@ older `_` prefix still works. Commands are case-insensitive.
 - **Daily "first" game** — members race to claim the first win of the day with
   `/1st`. Wins, streaks, and juice scores are tracked, with leaderboards and
   graphs. See the `first_game` topic for the full rules.
-- **DinkCoin (DINK)** — a fun server currency earned by winning `/1st` and sent
-  between members with `/pay`. See the `dinkcoin` topic.
+- **DinkCoin (DINK)** — a fun server currency earned by winning `/1st` and moved
+  between members with `/pay` or `/request`. See the `dinkcoin` topic.
 - **Chat & creativity** — `/ask` for questions and conversation (including images
   you attach), `/imagine` for AI art, `/voice` for a spoken reply, and `/clear`
   to start a fresh chat. See the `ai_features` topic.

--- a/docs/self_knowledge/server_stats.md
+++ b/docs/self_knowledge/server_stats.md
@@ -8,7 +8,7 @@ leaderboards, graphs, and the monthly report — not through raw data.
 - **Messages** — activity in channels (used for monthly rankings and the dashboard).
 - **First game** — every daily `/1st` win, which powers `/score`, `/stats`, `/juice`,
   and the graphs.
-- **DINK** — balances and transfers from `/pay` and `/1st` wins.
+- **DINK** — balances and transfers from `/pay`, `/request`, and `/1st` wins.
 - **AI usage** — `/ask`, `/imagine`, and related commands (for server records).
 
 ## What members see

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from utils.constants import GENERAL_CHANNEL_ID  # noqa: E402
 
 EXPECTED_COMMANDS = frozenset({
     "1st", "score", "stats", "juice", "graph", "juicegraph",
-    "balance", "ledger", "pay",
+    "balance", "ledger", "pay", "request",
     "ask", "imagine", "clear", "voice",
     "members", "emojis", "channels",
     "hello", "ping", "simonsays", "dashboard",

--- a/tests/test_bot_loading.py
+++ b/tests/test_bot_loading.py
@@ -44,4 +44,4 @@ def test_all_commands_registered(report):
     )
     report.record("command count", len(EXPECTED_COMMANDS), len(registered), section=SECTION_WIRING)
     assert EXPECTED_COMMANDS <= registered
-    assert len(EXPECTED_COMMANDS) == 21
+    assert len(EXPECTED_COMMANDS) == 22

--- a/tests/test_dinkcoin_commands.py
+++ b/tests/test_dinkcoin_commands.py
@@ -131,6 +131,7 @@ async def test_request_sends_buttons(mock_db_ops, mock_bot, mock_ctx):
 
 
 async def test_request_self(mock_db_ops, mock_bot, mock_ctx):
+    mock_ctx.author.bot = False
     cog = DinkCoin(mock_bot)
     await cog.request.callback(cog, mock_ctx, mock_ctx.author, 1)
 

--- a/tests/test_dinkcoin_commands.py
+++ b/tests/test_dinkcoin_commands.py
@@ -1,10 +1,10 @@
 """Mocked tests for DinkCoin cog commands."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pandas as pd
 
-from cogs.dinkcoin import DinkCoin
+from cogs.dinkcoin import DinkCoin, DinkRequestView
 
 
 async def test_balance(mock_db_ops, mock_bot, mock_ctx):
@@ -97,3 +97,126 @@ async def test_pay_self(mock_db_ops, mock_bot, mock_ctx):
     message = mock_ctx.send.call_args.args[0]
     assert "cannot pay yourself" in message.lower()
     mock_db_ops.record_dink_transfer.assert_not_called()
+
+
+def _make_member(user_id: int, mention: str | None = None, bot: bool = False):
+    member = MagicMock()
+    member.id = user_id
+    member.mention = mention or f"<@{user_id}>"
+    member.bot = bot
+    return member
+
+
+async def test_request_sends_buttons(mock_db_ops, mock_bot, mock_ctx):
+    payer = _make_member(222222222)
+    sent_message = MagicMock()
+    mock_ctx.send = AsyncMock(return_value=sent_message)
+    cog = DinkCoin(mock_bot)
+
+    await cog.request.callback(cog, mock_ctx, payer, 2)
+
+    args, kwargs = mock_ctx.send.call_args
+    message = args[0]
+    view = kwargs["view"]
+    assert "requesting" in message
+    assert "2 DINK" in message
+    assert isinstance(view, DinkRequestView)
+    assert view.payer_id == payer.id
+    assert view.requester_id == mock_ctx.author.id
+    assert view.amount == 2
+    assert view.message is sent_message
+    labels = [item.label for item in view.children]
+    assert labels == ["Accept", "Decline"]
+    mock_db_ops.record_dink_transfer.assert_not_called()
+
+
+async def test_request_self(mock_db_ops, mock_bot, mock_ctx):
+    cog = DinkCoin(mock_bot)
+    await cog.request.callback(cog, mock_ctx, mock_ctx.author, 1)
+
+    message = mock_ctx.send.call_args.args[0]
+    assert "yourself" in message.lower()
+    mock_db_ops.record_dink_transfer.assert_not_called()
+
+
+async def test_request_fractional_amount(mock_db_ops, mock_bot, mock_ctx):
+    payer = _make_member(222222222)
+    cog = DinkCoin(mock_bot)
+
+    await cog.request.callback(cog, mock_ctx, payer, 1.5)
+
+    message = mock_ctx.send.call_args.args[0]
+    assert "Only whole DINK coins" in message
+    mock_db_ops.record_dink_transfer.assert_not_called()
+
+
+async def test_request_accept_transfers(mock_db_ops, mock_bot, mock_ctx):
+    requester = _make_member(111111111)
+    payer = _make_member(222222222)
+    view = DinkRequestView(requester, payer, 2)
+    mock_db_ops.get_dink_balance.return_value = 5.0
+
+    interaction = AsyncMock()
+    interaction.user = payer
+    interaction.response = AsyncMock()
+
+    await view.accept.callback(interaction)
+
+    mock_db_ops.record_dink_transfer.assert_called_once_with(payer.id, requester.id, 2)
+    interaction.response.edit_message.assert_awaited_once()
+    content = interaction.response.edit_message.call_args.kwargs["content"]
+    assert "accepted" in content
+    assert all(item.disabled for item in view.children)
+
+
+async def test_request_accept_insufficient_balance(mock_db_ops, mock_bot, mock_ctx):
+    requester = _make_member(111111111)
+    payer = _make_member(222222222)
+    view = DinkRequestView(requester, payer, 2)
+    mock_db_ops.get_dink_balance.return_value = 1.0
+
+    interaction = AsyncMock()
+    interaction.user = payer
+    interaction.response = AsyncMock()
+
+    await view.accept.callback(interaction)
+
+    mock_db_ops.record_dink_transfer.assert_not_called()
+    interaction.response.send_message.assert_awaited_once()
+    message = interaction.response.send_message.call_args.args[0]
+    assert "Insufficient balance" in message
+    assert all(not item.disabled for item in view.children)
+
+
+async def test_request_decline(mock_db_ops, mock_bot, mock_ctx):
+    requester = _make_member(111111111)
+    payer = _make_member(222222222)
+    view = DinkRequestView(requester, payer, 2)
+
+    interaction = AsyncMock()
+    interaction.user = payer
+    interaction.response = AsyncMock()
+
+    await view.decline.callback(interaction)
+
+    mock_db_ops.record_dink_transfer.assert_not_called()
+    content = interaction.response.edit_message.call_args.kwargs["content"]
+    assert "declined" in content
+    assert all(item.disabled for item in view.children)
+
+
+async def test_request_wrong_user_blocked(mock_db_ops, mock_bot, mock_ctx):
+    requester = _make_member(111111111)
+    payer = _make_member(222222222)
+    outsider = _make_member(333333333)
+    view = DinkRequestView(requester, payer, 2)
+
+    interaction = AsyncMock()
+    interaction.user = outsider
+    interaction.response = AsyncMock()
+
+    allowed = await view.interaction_check(interaction)
+
+    assert allowed is False
+    interaction.response.send_message.assert_awaited_once()
+    assert interaction.response.send_message.call_args.kwargs["ephemeral"] is True


### PR DESCRIPTION
## Summary
- Add hybrid `/request` so a member can ask another member for a whole-number amount of DINK
- Show Accept / Decline buttons; only the requested user can respond, with a 5-minute timeout
- Accept runs the same transfer path as `/pay` (payer → requester) after a live balance check

## Test plan
- [ ] Run `/request @user 1` and confirm Accept/Decline buttons appear
- [ ] As the requested user, Accept and verify balances update for both users
- [ ] As the requested user, Decline and verify no transfer occurs
- [ ] Confirm other users get an ephemeral "only the requested user" message
- [ ] Confirm Accept with insufficient balance shows an ephemeral error and leaves buttons active
- [ ] Confirm bots / self / fractional amounts are rejected
- [ ] CI mocked dinkcoin tests pass
