### PR TITLE
Polish DINK request: primary Accept button and 24h timeout

### DIFF
--- a/cogs/dinkcoin.py
+++ b/cogs/dinkcoin.py
@@ -9,7 +9,7 @@ from utils.db import DatabaseError, db_ops
 
 logger = logging.getLogger(__name__)
 
-REQUEST_TIMEOUT_SECONDS = 300
+REQUEST_TIMEOUT_SECONDS = 24 * 60 * 60
 
 
 class DinkRequestView(discord.ui.View):
@@ -52,7 +52,7 @@ class DinkRequestView(discord.ui.View):
             except discord.HTTPException:
                 logger.exception("Failed to edit expired DINK request message")
 
-    @discord.ui.button(label="Accept", style=discord.ButtonStyle.success)
+    @discord.ui.button(label="Accept", style=discord.ButtonStyle.primary)
     async def accept(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):

--- a/docs/self_knowledge/dinkcoin.md
+++ b/docs/self_knowledge/dinkcoin.md
@@ -24,7 +24,7 @@ on any blockchain or crypto wallet.
 - You can't pay/request yourself or bots.
 - You can't send more than you have — the bot will tell you your balance if you try.
 - Only the person being asked can press Accept or Decline on a `/request`.
-- Pending requests expire after a few minutes if nobody responds.
+- Pending requests expire after 24 hours if nobody responds.
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- Change `/request` Accept button from green (`success`) to blurple (`primary`)
- Extend pending request timeout from 5 minutes to 24 hours
- Update self-knowledge docs to match

## Test plan
- [ ] Run `/request @user 1` and confirm Accept is blurple and Decline is red
- [ ] Confirm a pending request still works after a long wait (or that timeout is 24h in code)
- [ ] CI passes
