### PR TITLE
Add nightly Grok sentiment scoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,9 @@ XAI_API_KEY=
 
 # Optional: DINK awarded per successful /1st claim (default 1)
 DINK_MINT_AMOUNT=1
+
+# Nightly sentiment (cheap Grok via XAI_API_KEY — scores messages missing from message_sentiment)
+# GROK_SENTIMENT_MODEL=grok-4.3
+# SENTIMENT_BATCH_SIZE=15
+# Optional cap per nightly run (useful while catching up a backlog)
+# SENTIMENT_NIGHTLY_LIMIT=500

--- a/bot.py
+++ b/bot.py
@@ -39,6 +39,7 @@ class DinkBot(commands.Bot):
         await self.load_extension('cogs.ai')
         await self.load_extension('cogs.utility')
         await self.load_extension('cogs.misc')
+        await self.load_extension('cogs.sentiment')
 
         await self._sync_app_commands()
         self.loop.create_task(self._console_post_loop())

--- a/cogs/sentiment.py
+++ b/cogs/sentiment.py
@@ -1,0 +1,53 @@
+"""Nightly incremental Grok sentiment scoring for new messages."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import time
+
+import pytz
+from discord.ext import commands, tasks
+
+from utils.sentiment_job import run_sentiment_nightly, sentiment_enabled
+
+logger = logging.getLogger(__name__)
+EASTERN = pytz.timezone("US/Eastern")
+# 4:15 AM Eastern — incremental catch-up for messages missing sentiment rows.
+NIGHTLY_AT = time(hour=4, minute=15, tzinfo=EASTERN)
+
+
+class Sentiment(commands.Cog):
+    """Schedule incremental message sentiment scoring with cheap Grok."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self._enabled = sentiment_enabled()
+        if self._enabled:
+            self.nightly_sentiment.start()
+        else:
+            logger.warning(
+                "Sentiment cog loaded but XAI_API_KEY is missing; nightly job disabled."
+            )
+
+    def cog_unload(self):
+        if self.nightly_sentiment.is_running():
+            self.nightly_sentiment.cancel()
+
+    @tasks.loop(time=NIGHTLY_AT)
+    async def nightly_sentiment(self):
+        """Score messages missing from message_sentiment (idempotent)."""
+        loop = asyncio.get_running_loop()
+        try:
+            written = await loop.run_in_executor(None, run_sentiment_nightly)
+            logger.info("Nightly sentiment wrote %s rows", written)
+        except Exception:
+            logger.exception("Nightly sentiment job crashed")
+
+    @nightly_sentiment.before_loop
+    async def before_nightly_sentiment(self):
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot):
+    await bot.add_cog(Sentiment(bot))

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tzdata
 requests
 python-dotenv
 xai-sdk>=1.17.0
+pydantic>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ tzdata
 requests
 python-dotenv
 xai-sdk>=1.17.0
-pydantic>=2.0

--- a/tests/test_bot_loading.py
+++ b/tests/test_bot_loading.py
@@ -6,20 +6,26 @@ from cogs.ai import AI
 from cogs.dinkcoin import DinkCoin
 from cogs.first import First
 from cogs.misc import Misc
+from cogs.sentiment import Sentiment
 from cogs.server import Server
 from cogs.utility import Utility
 from tests.conftest import EXPECTED_COMMANDS
 from tests.reporting import SECTION_WIRING
 
-COG_CLASSES = (First, DinkCoin, Server, AI, Utility, Misc)
+COG_CLASSES = (First, DinkCoin, Server, AI, Utility, Misc, Sentiment)
 
 
 def _server_init_without_tasks(self, bot):
     self.bot = bot
 
 
+def _sentiment_init_without_tasks(self, bot):
+    self.bot = bot
+    self._enabled = False
+
+
 def test_all_cogs_have_expected_names(report):
-    expected = {"First", "DinkCoin", "Server", "AI", "Utility", "Misc"}
+    expected = {"First", "DinkCoin", "Server", "AI", "Utility", "Misc", "Sentiment"}
     actual = {cls.__name__ for cls in COG_CLASSES}
     report.record("cog class names", sorted(expected), sorted(actual), section=SECTION_WIRING)
     assert actual == expected
@@ -31,10 +37,11 @@ def test_all_commands_registered(report):
 
     with patch("cogs.ai.GrokClient"):
         with patch.object(Server, "__init__", _server_init_without_tasks):
-            for cls in COG_CLASSES:
-                cog = cls(mock_bot)
-                for cmd in cog.get_commands():
-                    registered.add(cmd.name)
+            with patch.object(Sentiment, "__init__", _sentiment_init_without_tasks):
+                for cls in COG_CLASSES:
+                    cog = cls(mock_bot)
+                    for cmd in cog.get_commands():
+                        registered.add(cmd.name)
 
     report.record(
         "registered commands",

--- a/tests/test_sentiment_job.py
+++ b/tests/test_sentiment_job.py
@@ -1,0 +1,182 @@
+"""Tests for nightly Grok sentiment job wiring."""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from cogs.sentiment import Sentiment
+from utils import sentiment_job
+from utils.sentiment_prompt import SYSTEM_PROMPT, build_batch_user_prompt
+from utils.sentiment_schema import (
+    ALLOWED_EMOTIONS,
+    Polarity,
+    SentimentBatchResponse,
+    SentimentResult,
+    Toxicity,
+    DirectedAt,
+)
+
+
+def test_system_prompt_lists_allowed_emotions():
+    for emotion in ALLOWED_EMOTIONS:
+        assert emotion in SYSTEM_PROMPT
+
+
+def test_build_batch_user_prompt_includes_message_ids():
+    prompt = build_batch_user_prompt(
+        [
+            {
+                "message_id": "111",
+                "channel_name": "general",
+                "context_text": ">>> TARGET [alice] hello",
+            }
+        ]
+    )
+    assert "message_id: 111" in prompt
+    assert "#general" in prompt
+
+
+def test_format_context_block_marks_target():
+    text = sentiment_job.format_context_block(
+        [("bob", "prior msg")],
+        "alice",
+        "target msg",
+    )
+    assert ">>> TARGET [alice] target msg" in text
+    assert "[bob] prior msg" in text
+
+
+def test_sentiment_enabled_requires_api_key(monkeypatch):
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    assert sentiment_job.sentiment_enabled() is False
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+    assert sentiment_job.sentiment_enabled() is True
+
+
+def test_sentiment_model_default_and_override(monkeypatch):
+    monkeypatch.delenv("GROK_SENTIMENT_MODEL", raising=False)
+    assert sentiment_job.sentiment_model() == "grok-4.3"
+    monkeypatch.setenv("GROK_SENTIMENT_MODEL", "grok-build-0.1")
+    assert sentiment_job.sentiment_model() == "grok-build-0.1"
+
+
+def test_iter_batches():
+    items = [{"message_id": str(i)} for i in range(10)]
+    batches = sentiment_job.iter_batches(items, 4)
+    assert [len(b) for b in batches] == [4, 4, 2]
+
+
+def test_upsert_results_writes_rows():
+    result = SentimentResult(
+        message_id="123",
+        polarity=Polarity.POSITIVE,
+        polarity_score=0.5,
+        emotions=["joy"],
+        sarcasm=False,
+        toxicity=Toxicity.NONE,
+        directed_at=DirectedAt.GENERAL,
+        confidence=0.9,
+        rationale="Friendly greeting",
+    )
+    with patch.object(sentiment_job.db_ops.db, "executemany") as execmany:
+        written = sentiment_job.upsert_results([result], model="grok-4.3")
+    assert written == 1
+    execmany.assert_called_once()
+    rows = execmany.call_args.args[1]
+    assert rows[0][0] == 123
+    assert rows[0][1] == "positive"
+    assert rows[0][3] == "joy"
+    assert rows[0][9] == "grok-4.3"
+
+
+def test_run_sentiment_nightly_scores_and_upserts(monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+    unscored = pd.DataFrame(
+        [
+            {
+                "message_id": 99,
+                "member_id": "1",
+                "channel_id": 2,
+                "content": "gg",
+                "created_at": pd.Timestamp("2026-07-20"),
+                "author_name": "alice",
+                "channel_name": "general",
+            }
+        ]
+    )
+    scored = [
+        SentimentResult(
+            message_id="99",
+            polarity=Polarity.POSITIVE,
+            polarity_score=0.4,
+            emotions=["amusement"],
+            sarcasm=False,
+            toxicity=Toxicity.NONE,
+            directed_at=DirectedAt.TOPIC,
+            confidence=0.8,
+            rationale="Casual cheer",
+        )
+    ]
+
+    with patch.object(sentiment_job, "ensure_sentiment_table"):
+        with patch.object(sentiment_job, "fetch_unscored_messages", return_value=unscored):
+            with patch.object(
+                sentiment_job,
+                "build_prompt_items",
+                return_value=[
+                    {
+                        "message_id": "99",
+                        "channel_name": "general",
+                        "context_text": ">>> TARGET [alice] gg",
+                    }
+                ],
+            ):
+                with patch.object(
+                    sentiment_job, "score_batch_with_grok", return_value=scored
+                ) as score:
+                    with patch.object(sentiment_job, "upsert_results", return_value=1) as upsert:
+                        written = sentiment_job.run_sentiment_nightly(limit=1)
+
+    assert written == 1
+    score.assert_called_once()
+    assert score.call_args.kwargs["model"] == "grok-4.3"
+    upsert.assert_called_once_with(scored, model="grok-4.3")
+
+
+def test_sentiment_batch_response_round_trip():
+    payload = {
+        "results": [
+            {
+                "message_id": "42",
+                "polarity": "neutral",
+                "polarity_score": 0.0,
+                "emotions": ["neutral"],
+                "sarcasm": False,
+                "toxicity": "none",
+                "directed_at": "general",
+                "confidence": 0.7,
+                "rationale": "No clear valence",
+            }
+        ]
+    }
+    parsed = SentimentBatchResponse.model_validate(payload)
+    assert parsed.results[0].message_id == "42"
+
+
+def test_sentiment_cog_starts_when_api_key_present(monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+    bot = MagicMock()
+    with patch("discord.ext.tasks.Loop.start") as start:
+        cog = Sentiment(bot)
+    assert cog._enabled is True
+    start.assert_called_once()
+
+
+def test_sentiment_cog_disabled_without_api_key(monkeypatch):
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    bot = MagicMock()
+    with patch("discord.ext.tasks.Loop.start") as start:
+        cog = Sentiment(bot)
+    assert cog._enabled is False
+    start.assert_not_called()

--- a/tests/test_sentiment_job.py
+++ b/tests/test_sentiment_job.py
@@ -3,18 +3,14 @@
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
-import pytest
 
 from cogs.sentiment import Sentiment
 from utils import sentiment_job
 from utils.sentiment_prompt import SYSTEM_PROMPT, build_batch_user_prompt
 from utils.sentiment_schema import (
     ALLOWED_EMOTIONS,
-    Polarity,
-    SentimentBatchResponse,
     SentimentResult,
-    Toxicity,
-    DirectedAt,
+    parse_sentiment_batch,
 )
 
 
@@ -70,12 +66,12 @@ def test_iter_batches():
 def test_upsert_results_writes_rows():
     result = SentimentResult(
         message_id="123",
-        polarity=Polarity.POSITIVE,
+        polarity="positive",
         polarity_score=0.5,
         emotions=["joy"],
         sarcasm=False,
-        toxicity=Toxicity.NONE,
-        directed_at=DirectedAt.GENERAL,
+        toxicity="none",
+        directed_at="general",
         confidence=0.9,
         rationale="Friendly greeting",
     )
@@ -108,12 +104,12 @@ def test_run_sentiment_nightly_scores_and_upserts(monkeypatch):
     scored = [
         SentimentResult(
             message_id="99",
-            polarity=Polarity.POSITIVE,
+            polarity="positive",
             polarity_score=0.4,
             emotions=["amusement"],
             sarcasm=False,
-            toxicity=Toxicity.NONE,
-            directed_at=DirectedAt.TOPIC,
+            toxicity="none",
+            directed_at="topic",
             confidence=0.8,
             rationale="Casual cheer",
         )
@@ -144,7 +140,7 @@ def test_run_sentiment_nightly_scores_and_upserts(monkeypatch):
     upsert.assert_called_once_with(scored, model="grok-4.3")
 
 
-def test_sentiment_batch_response_round_trip():
+def test_parse_sentiment_batch_round_trip():
     payload = {
         "results": [
             {
@@ -160,8 +156,9 @@ def test_sentiment_batch_response_round_trip():
             }
         ]
     }
-    parsed = SentimentBatchResponse.model_validate(payload)
-    assert parsed.results[0].message_id == "42"
+    parsed = parse_sentiment_batch(payload)
+    assert parsed[0].message_id == "42"
+    assert parsed[0].polarity == "neutral"
 
 
 def test_sentiment_cog_starts_when_api_key_present(monkeypatch):

--- a/utils/sentiment_job.py
+++ b/utils/sentiment_job.py
@@ -6,6 +6,7 @@ prompt/schema shape as the Sentiment-Analysis backfill so rows stay compatible.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import time
@@ -18,7 +19,7 @@ from xai_sdk.chat import system, user
 
 from utils.db import db_ops
 from utils.sentiment_prompt import SYSTEM_PROMPT, build_batch_user_prompt
-from utils.sentiment_schema import SentimentBatchResponse, SentimentResult
+from utils.sentiment_schema import SentimentResult, parse_sentiment_batch
 
 load_dotenv()
 
@@ -240,12 +241,14 @@ def score_batch_with_grok(
                 model=model,
                 temperature=0.2,
                 reasoning_effort="none",
+                response_format="json_object",
                 store_messages=False,
             )
             chat.append(system(SYSTEM_PROMPT))
             chat.append(user(user_prompt))
-            _response, parsed = chat.parse(SentimentBatchResponse)
-            results = [r for r in parsed.results if r.message_id in expected_ids]
+            response = chat.sample()
+            parsed = parse_sentiment_batch(json.loads(response.content))
+            results = [r for r in parsed if r.message_id in expected_ids]
             got_ids = {r.message_id for r in results}
             missing = expected_ids - got_ids
             if missing:
@@ -276,12 +279,12 @@ def upsert_results(results: list[SentimentResult], *, model: str) -> int:
         rows.append(
             (
                 int(mid),
-                r.polarity.value,
+                r.polarity,
                 float(r.polarity_score),
                 ",".join(r.emotions),
                 int(bool(r.sarcasm)),
-                r.toxicity.value,
-                r.directed_at.value,
+                r.toxicity,
+                r.directed_at,
                 float(r.confidence),
                 r.rationale[:255],
                 model,

--- a/utils/sentiment_job.py
+++ b/utils/sentiment_job.py
@@ -1,0 +1,328 @@
+"""Incremental nightly sentiment scoring with cheap Grok (xAI).
+
+Only scores messages that are not yet in message_sentiment. Uses the same
+prompt/schema shape as the Sentiment-Analysis backfill so rows stay compatible.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+import pandas as pd
+from dotenv import load_dotenv
+from xai_sdk import Client
+from xai_sdk.chat import system, user
+
+from utils.db import db_ops
+from utils.sentiment_prompt import SYSTEM_PROMPT, build_batch_user_prompt
+from utils.sentiment_schema import SentimentBatchResponse, SentimentResult
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+# grok-4.3 + reasoning_effort=none is the cheap chat path after fast-model retirement.
+DEFAULT_SENTIMENT_MODEL = "grok-4.3"
+DEFAULT_BATCH_SIZE = 15
+DEFAULT_CONTEXT_SIZE = 3
+DEFAULT_MAX_CONTENT_CHARS = 500
+DEFAULT_MAX_RETRIES = 3
+
+ENSURE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS message_sentiment (
+  message_id BIGINT(20) NOT NULL,
+  polarity ENUM('positive','negative','neutral','mixed') NOT NULL,
+  polarity_score FLOAT NOT NULL,
+  emotions VARCHAR(128) NOT NULL,
+  sarcasm TINYINT(1) NOT NULL,
+  toxicity ENUM('none','mild','moderate','severe') NOT NULL,
+  directed_at ENUM('general','person','group','self','topic') NOT NULL,
+  confidence FLOAT NOT NULL,
+  rationale VARCHAR(255) NOT NULL,
+  model VARCHAR(64) NOT NULL,
+  scored_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (message_id),
+  KEY idx_sentiment_scored_at (scored_at),
+  KEY idx_sentiment_polarity (polarity),
+  CONSTRAINT fk_sentiment_message FOREIGN KEY (message_id) REFERENCES messages (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+"""
+
+UNSCORED_SQL = """
+SELECT
+    m.id AS message_id,
+    m.member_id,
+    m.channel_id,
+    m.content,
+    m.created_at,
+    COALESCE(mem.display_name, mem.user_name, m.member_id) AS author_name,
+    COALESCE(c.channel_name, 'unknown') AS channel_name
+FROM messages m
+LEFT JOIN members mem ON m.member_id = mem.id
+LEFT JOIN channels c ON m.channel_id = c.id
+LEFT JOIN message_sentiment s ON s.message_id = m.id
+WHERE s.message_id IS NULL
+  AND m.content IS NOT NULL
+  AND TRIM(m.content) <> ''
+ORDER BY m.channel_id, m.created_at, m.id
+"""
+
+PRIORS_SQL = """
+SELECT
+    m.id,
+    m.member_id,
+    m.content,
+    m.created_at,
+    COALESCE(mem.display_name, mem.user_name, m.member_id) AS author_name
+FROM messages m
+LEFT JOIN members mem ON m.member_id = mem.id
+WHERE m.channel_id = %s
+  AND (
+    m.created_at < %s
+    OR (m.created_at = %s AND m.id < %s)
+  )
+ORDER BY m.created_at DESC, m.id DESC
+LIMIT %s
+"""
+
+UPSERT_SQL = """
+INSERT INTO message_sentiment (
+  message_id, polarity, polarity_score, emotions, sarcasm, toxicity,
+  directed_at, confidence, rationale, model
+) VALUES (
+  %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+)
+ON DUPLICATE KEY UPDATE
+  polarity = VALUES(polarity),
+  polarity_score = VALUES(polarity_score),
+  emotions = VALUES(emotions),
+  sarcasm = VALUES(sarcasm),
+  toxicity = VALUES(toxicity),
+  directed_at = VALUES(directed_at),
+  confidence = VALUES(confidence),
+  rationale = VALUES(rationale),
+  model = VALUES(model),
+  updated_at = CURRENT_TIMESTAMP
+"""
+
+
+def sentiment_model() -> str:
+    return os.getenv("GROK_SENTIMENT_MODEL", DEFAULT_SENTIMENT_MODEL).strip() or DEFAULT_SENTIMENT_MODEL
+
+
+def sentiment_enabled() -> bool:
+    return bool(os.getenv("XAI_API_KEY", "").strip())
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    text = text.replace("\n", " ").strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 1] + "…"
+
+
+def format_context_block(
+    priors: list[tuple[str, str]],
+    target_author: str,
+    target_content: str,
+    max_content_chars: int = DEFAULT_MAX_CONTENT_CHARS,
+) -> str:
+    lines: list[str] = []
+    for author, content in priors:
+        lines.append(f"[{_truncate(author, 40)}] {_truncate(content, max_content_chars)}")
+    lines.append(
+        f">>> TARGET [{_truncate(target_author, 40)}] "
+        f"{_truncate(target_content, max_content_chars)}"
+    )
+    return "\n".join(lines)
+
+
+def ensure_sentiment_table() -> None:
+    db_ops.db.execute(ENSURE_TABLE_SQL)
+
+
+def fetch_unscored_messages(limit: int | None = None) -> pd.DataFrame:
+    df = db_ops.db.fetch_df(UNSCORED_SQL)
+    if df.empty:
+        return df
+    if limit is not None:
+        df = df.head(limit).copy()
+    df["message_id"] = df["message_id"].astype("int64")
+    df["created_at"] = pd.to_datetime(df["created_at"])
+    df["content"] = df["content"].fillna("").astype(str)
+    df["author_name"] = df["author_name"].fillna("unknown").astype(str)
+    df["channel_name"] = df["channel_name"].fillna("unknown").astype(str)
+    return df
+
+
+def fetch_priors(
+    channel_id: Any,
+    created_at: Any,
+    message_id: int,
+    *,
+    context_size: int = DEFAULT_CONTEXT_SIZE,
+) -> list[tuple[str, str]]:
+    """Return up to context_size prior in-channel messages oldest→newest."""
+    df = db_ops.db.fetch_df(
+        PRIORS_SQL,
+        (channel_id, created_at, created_at, message_id, context_size),
+    )
+    if df.empty:
+        return []
+    # Query returns newest-first; prompt wants chronological priors.
+    rows = list(reversed(df.to_dict(orient="records")))
+    priors: list[tuple[str, str]] = []
+    for row in rows:
+        content = str(row.get("content") or "").strip()
+        if not content:
+            continue
+        author = str(row.get("author_name") or "unknown")
+        priors.append((author, content))
+    return priors
+
+
+def build_prompt_items(
+    unscored: pd.DataFrame,
+    *,
+    context_size: int = DEFAULT_CONTEXT_SIZE,
+    max_content_chars: int = DEFAULT_MAX_CONTENT_CHARS,
+) -> list[dict]:
+    items: list[dict] = []
+    for row in unscored.itertuples(index=False):
+        priors = fetch_priors(
+            row.channel_id,
+            row.created_at,
+            int(row.message_id),
+            context_size=context_size,
+        )
+        items.append(
+            {
+                "message_id": str(row.message_id),
+                "channel_name": str(row.channel_name),
+                "context_text": format_context_block(
+                    priors,
+                    str(row.author_name),
+                    str(row.content),
+                    max_content_chars=max_content_chars,
+                ),
+            }
+        )
+    return items
+
+
+def iter_batches(items: list[dict], batch_size: int) -> list[list[dict]]:
+    return [items[i : i + batch_size] for i in range(0, len(items), batch_size)]
+
+
+def score_batch_with_grok(
+    items: list[dict],
+    *,
+    model: str,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> list[SentimentResult]:
+    """Score one batch via Grok structured JSON (no tools / no reasoning)."""
+    api_key = os.getenv("XAI_API_KEY", "").strip()
+    if not api_key:
+        raise RuntimeError("XAI_API_KEY is required for sentiment scoring")
+
+    client = Client(api_key=api_key, timeout=600)
+    user_prompt = build_batch_user_prompt(items)
+    expected_ids = {item["message_id"] for item in items}
+    last_error: Exception | None = None
+
+    for attempt in range(max_retries):
+        try:
+            chat = client.chat.create(
+                model=model,
+                temperature=0.2,
+                reasoning_effort="none",
+                store_messages=False,
+            )
+            chat.append(system(SYSTEM_PROMPT))
+            chat.append(user(user_prompt))
+            _response, parsed = chat.parse(SentimentBatchResponse)
+            results = [r for r in parsed.results if r.message_id in expected_ids]
+            got_ids = {r.message_id for r in results}
+            missing = expected_ids - got_ids
+            if missing:
+                raise ValueError(f"Model omitted message_ids: {sorted(missing)[:5]}")
+            return results
+        except Exception as exc:  # noqa: BLE001 — retry transient/parse failures
+            last_error = exc
+            logger.warning(
+                "Sentiment batch attempt %s/%s failed: %s",
+                attempt + 1,
+                max_retries,
+                exc,
+            )
+            time.sleep(1.5 * (attempt + 1))
+
+    raise RuntimeError(f"Sentiment batch failed after {max_retries} attempts: {last_error}")
+
+
+def upsert_results(results: list[SentimentResult], *, model: str) -> int:
+    if not results:
+        return 0
+    rows = []
+    for r in results:
+        mid = str(r.message_id).strip()
+        if not mid.isdigit() or len(mid) > 20:
+            logger.warning("Skipping invalid message_id=%r", mid)
+            continue
+        rows.append(
+            (
+                int(mid),
+                r.polarity.value,
+                float(r.polarity_score),
+                ",".join(r.emotions),
+                int(bool(r.sarcasm)),
+                r.toxicity.value,
+                r.directed_at.value,
+                float(r.confidence),
+                r.rationale[:255],
+                model,
+            )
+        )
+    if not rows:
+        return 0
+    db_ops.db.executemany(UPSERT_SQL, rows)
+    return len(rows)
+
+
+def run_sentiment_nightly(*, limit: int | None = None) -> int:
+    """
+    Score unscored messages with Grok and upsert into message_sentiment.
+
+    Returns number of rows written.
+    """
+    if not sentiment_enabled():
+        raise RuntimeError("XAI_API_KEY is required for sentiment scoring")
+
+    if limit is None:
+        raw = os.getenv("SENTIMENT_NIGHTLY_LIMIT", "").strip()
+        if raw:
+            limit = int(raw)
+
+    batch_size = int(os.getenv("SENTIMENT_BATCH_SIZE", str(DEFAULT_BATCH_SIZE)))
+    model = sentiment_model()
+
+    ensure_sentiment_table()
+    unscored = fetch_unscored_messages(limit=limit)
+    if unscored.empty:
+        logger.info("No unscored messages")
+        return 0
+
+    items = build_prompt_items(unscored)
+    logger.info("Scoring %s unscored messages with %s...", len(items), model)
+
+    written = 0
+    for batch in iter_batches(items, batch_size):
+        results = score_batch_with_grok(batch, model=model)
+        written += upsert_results(results, model=model)
+
+    logger.info("Upserted %s sentiment rows", written)
+    return written

--- a/utils/sentiment_prompt.py
+++ b/utils/sentiment_prompt.py
@@ -1,0 +1,47 @@
+"""Prompt templates for contextual Discord sentiment scoring."""
+
+from __future__ import annotations
+
+from utils.sentiment_schema import ALLOWED_EMOTIONS
+
+SYSTEM_PROMPT = f"""You are analyzing Discord chat messages for sentiment.
+
+For each item, score ONLY the message marked >>> TARGET.
+Use the preceding messages solely as local context (sarcasm, irony, in-jokes, replies).
+
+Return JSON with a top-level "results" array. Each element must include:
+- message_id (string, copy exactly from the item)
+- polarity: positive | negative | neutral | mixed
+- polarity_score: float from -1 (very negative) to 1 (very positive); mixed near 0
+- emotions: 1–3 labels from this fixed set only: {", ".join(sorted(ALLOWED_EMOTIONS))}
+- sarcasm: boolean (true if ironic / sarcastic given context)
+- toxicity: none | mild | moderate | severe
+- directed_at: general | person | group | self | topic
+- confidence: 0–1
+- rationale: at most 15 words
+
+Rules:
+- Short Discord slang (lol, lmao, gg) can still carry clear polarity.
+- Prefer sarcasm=true when surface polarity conflicts with context.
+- Keep rationales terse; do not quote long message text.
+- Output one result per input item, same order, same message_ids.
+"""
+
+
+def build_batch_user_prompt(items: list[dict]) -> str:
+    """Build the user prompt for a batch of targets.
+
+    Each item needs: message_id, channel_name, context_text
+    """
+    blocks: list[str] = [
+        f"Analyze {len(items)} Discord message(s). "
+        'Return JSON {"results": [...]} with one object per item.\n'
+    ]
+    for idx, item in enumerate(items, start=1):
+        blocks.append(
+            f"--- ITEM {idx} ---\n"
+            f"message_id: {item['message_id']}\n"
+            f"channel: #{item.get('channel_name', 'unknown')}\n"
+            f"{item['context_text']}\n"
+        )
+    return "\n".join(blocks)

--- a/utils/sentiment_schema.py
+++ b/utils/sentiment_schema.py
@@ -1,35 +1,15 @@
-"""Pydantic schema for nightly Discord sentiment scoring (matches message_sentiment)."""
+"""Plain validation for nightly Discord sentiment scoring (matches message_sentiment)."""
 
 from __future__ import annotations
 
-from enum import Enum
+import json
+from dataclasses import dataclass
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
 
-
-class Polarity(str, Enum):
-    POSITIVE = "positive"
-    NEGATIVE = "negative"
-    NEUTRAL = "neutral"
-    MIXED = "mixed"
-
-
-class Toxicity(str, Enum):
-    NONE = "none"
-    MILD = "mild"
-    MODERATE = "moderate"
-    SEVERE = "severe"
-
-
-class DirectedAt(str, Enum):
-    GENERAL = "general"
-    PERSON = "person"
-    GROUP = "group"
-    SELF = "self"
-    TOPIC = "topic"
-
-
+POLARITIES = frozenset({"positive", "negative", "neutral", "mixed"})
+TOXICITIES = frozenset({"none", "mild", "moderate", "severe"})
+DIRECTED_ATS = frozenset({"general", "person", "group", "self", "topic"})
 ALLOWED_EMOTIONS = frozenset(
     {
         "joy",
@@ -45,46 +25,88 @@ ALLOWED_EMOTIONS = frozenset(
 )
 
 
-class SentimentResult(BaseModel):
+@dataclass(frozen=True)
+class SentimentResult:
     message_id: str
-    polarity: Polarity
-    polarity_score: float = Field(..., ge=-1.0, le=1.0)
-    emotions: list[str] = Field(..., min_length=1, max_length=3)
+    polarity: str
+    polarity_score: float
+    emotions: list[str]
     sarcasm: bool
-    toxicity: Toxicity
-    directed_at: DirectedAt
-    confidence: float = Field(..., ge=0.0, le=1.0)
-    rationale: str = Field(..., max_length=200)
-
-    @field_validator("emotions")
-    @classmethod
-    def validate_emotions(cls, values: list[str]) -> list[str]:
-        cleaned: list[str] = []
-        for emotion in values:
-            key = emotion.strip().lower()
-            if key not in ALLOWED_EMOTIONS:
-                raise ValueError(
-                    f"emotion '{emotion}' not in {sorted(ALLOWED_EMOTIONS)}"
-                )
-            if key not in cleaned:
-                cleaned.append(key)
-        if not cleaned:
-            raise ValueError("emotions must contain at least one label")
-        return cleaned[:3]
-
-    @field_validator("rationale")
-    @classmethod
-    def shorten_rationale(cls, value: str) -> str:
-        words = value.strip().split()
-        if len(words) > 15:
-            return " ".join(words[:15])
-        return value.strip()
-
-    @field_validator("message_id", mode="before")
-    @classmethod
-    def coerce_message_id(cls, value: Any) -> str:
-        return str(value)
+    toxicity: str
+    directed_at: str
+    confidence: float
+    rationale: str
 
 
-class SentimentBatchResponse(BaseModel):
-    results: list[SentimentResult]
+def _shorten_rationale(value: str) -> str:
+    words = value.strip().split()
+    if len(words) > 15:
+        return " ".join(words[:15])
+    return value.strip()
+
+
+def _clean_emotions(values: Any) -> list[str]:
+    if not isinstance(values, list) or not values:
+        raise ValueError("emotions must be a non-empty list")
+    cleaned: list[str] = []
+    for emotion in values:
+        key = str(emotion).strip().lower()
+        if key not in ALLOWED_EMOTIONS:
+            raise ValueError(f"emotion '{emotion}' not in {sorted(ALLOWED_EMOTIONS)}")
+        if key not in cleaned:
+            cleaned.append(key)
+    if not cleaned:
+        raise ValueError("emotions must contain at least one label")
+    return cleaned[:3]
+
+
+def parse_sentiment_result(raw: Any) -> SentimentResult:
+    if not isinstance(raw, dict):
+        raise ValueError("result must be an object")
+
+    message_id = str(raw.get("message_id", "")).strip()
+    if not message_id:
+        raise ValueError("message_id is required")
+
+    polarity = str(raw.get("polarity", "")).strip().lower()
+    if polarity not in POLARITIES:
+        raise ValueError(f"invalid polarity: {polarity!r}")
+
+    toxicity = str(raw.get("toxicity", "")).strip().lower()
+    if toxicity not in TOXICITIES:
+        raise ValueError(f"invalid toxicity: {toxicity!r}")
+
+    directed_at = str(raw.get("directed_at", "")).strip().lower()
+    if directed_at not in DIRECTED_ATS:
+        raise ValueError(f"invalid directed_at: {directed_at!r}")
+
+    polarity_score = float(raw["polarity_score"])
+    if polarity_score < -1.0 or polarity_score > 1.0:
+        raise ValueError(f"polarity_score out of range: {polarity_score}")
+
+    confidence = float(raw["confidence"])
+    if confidence < 0.0 or confidence > 1.0:
+        raise ValueError(f"confidence out of range: {confidence}")
+
+    return SentimentResult(
+        message_id=message_id,
+        polarity=polarity,
+        polarity_score=polarity_score,
+        emotions=_clean_emotions(raw.get("emotions")),
+        sarcasm=bool(raw.get("sarcasm")),
+        toxicity=toxicity,
+        directed_at=directed_at,
+        confidence=confidence,
+        rationale=_shorten_rationale(str(raw.get("rationale", ""))),
+    )
+
+
+def parse_sentiment_batch(payload: Any) -> list[SentimentResult]:
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    if not isinstance(payload, dict):
+        raise ValueError("batch response must be an object")
+    results = payload.get("results")
+    if not isinstance(results, list) or not results:
+        raise ValueError("results must be a non-empty list")
+    return [parse_sentiment_result(item) for item in results]

--- a/utils/sentiment_schema.py
+++ b/utils/sentiment_schema.py
@@ -1,0 +1,90 @@
+"""Pydantic schema for nightly Discord sentiment scoring (matches message_sentiment)."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class Polarity(str, Enum):
+    POSITIVE = "positive"
+    NEGATIVE = "negative"
+    NEUTRAL = "neutral"
+    MIXED = "mixed"
+
+
+class Toxicity(str, Enum):
+    NONE = "none"
+    MILD = "mild"
+    MODERATE = "moderate"
+    SEVERE = "severe"
+
+
+class DirectedAt(str, Enum):
+    GENERAL = "general"
+    PERSON = "person"
+    GROUP = "group"
+    SELF = "self"
+    TOPIC = "topic"
+
+
+ALLOWED_EMOTIONS = frozenset(
+    {
+        "joy",
+        "anger",
+        "annoyance",
+        "amusement",
+        "sadness",
+        "fear",
+        "surprise",
+        "disgust",
+        "neutral",
+    }
+)
+
+
+class SentimentResult(BaseModel):
+    message_id: str
+    polarity: Polarity
+    polarity_score: float = Field(..., ge=-1.0, le=1.0)
+    emotions: list[str] = Field(..., min_length=1, max_length=3)
+    sarcasm: bool
+    toxicity: Toxicity
+    directed_at: DirectedAt
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    rationale: str = Field(..., max_length=200)
+
+    @field_validator("emotions")
+    @classmethod
+    def validate_emotions(cls, values: list[str]) -> list[str]:
+        cleaned: list[str] = []
+        for emotion in values:
+            key = emotion.strip().lower()
+            if key not in ALLOWED_EMOTIONS:
+                raise ValueError(
+                    f"emotion '{emotion}' not in {sorted(ALLOWED_EMOTIONS)}"
+                )
+            if key not in cleaned:
+                cleaned.append(key)
+        if not cleaned:
+            raise ValueError("emotions must contain at least one label")
+        return cleaned[:3]
+
+    @field_validator("rationale")
+    @classmethod
+    def shorten_rationale(cls, value: str) -> str:
+        words = value.strip().split()
+        if len(words) > 15:
+            return " ".join(words[:15])
+        return value.strip()
+
+    @field_validator("message_id", mode="before")
+    @classmethod
+    def coerce_message_id(cls, value: Any) -> str:
+        return str(value)
+
+
+class SentimentBatchResponse(BaseModel):
+    results: list[SentimentResult]


### PR DESCRIPTION
## Summary
- Adds a 4:15 AM Eastern scheduled cog that scores messages missing from `message_sentiment`
- Uses cheap `grok-4.3` (`reasoning_effort=none`) via existing `XAI_API_KEY` / xai-sdk
- Keeps message inserts unchanged; upserts are idempotent and resume-safe

## Test plan
- [ ] Unit tests: `pytest tests/test_sentiment_job.py tests/test_bot_loading.py`
- [ ] Confirm cog loads when `XAI_API_KEY` is set; disabled cleanly when missing
- [ ] Smoke: run `run_sentiment_nightly(limit=1)` and verify a `grok-4.3` row in `message_sentiment`
- [ ] Optional: set `SENTIMENT_NIGHTLY_LIMIT` while catching up backlog