### PR TITLE
Score sentiment one message at a time with resilient error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,5 @@ DINK_MINT_AMOUNT=1
 
 # Nightly sentiment (cheap Grok via XAI_API_KEY — scores messages missing from message_sentiment)
 # GROK_SENTIMENT_MODEL=grok-4.3
-# SENTIMENT_BATCH_SIZE=15
-# Optional cap per nightly run (useful while catching up a backlog)
+# Optional cap per run (newest unscored first; useful while catching up historical holes)
 # SENTIMENT_NIGHTLY_LIMIT=500

--- a/cogs/sentiment.py
+++ b/cogs/sentiment.py
@@ -64,7 +64,7 @@ class Sentiment(commands.Cog):
 
     @commands.hybrid_command(brief="Score unscored messages with Grok sentiment")
     @app_commands.describe(
-        limit="Max messages to score (omit for all unscored / SENTIMENT_NIGHTLY_LIMIT)",
+        limit="Max messages to score, newest first (omit for all / SENTIMENT_NIGHTLY_LIMIT)",
     )
     async def score_sentiment(self, ctx, limit: int | None = None):
         """Manually kick off incremental sentiment scoring for unscored messages."""

--- a/tests/test_sentiment_job.py
+++ b/tests/test_sentiment_job.py
@@ -3,34 +3,38 @@
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+import pytest
 
 from cogs.sentiment import Sentiment
 from utils import sentiment_job
-from utils.sentiment_prompt import SYSTEM_PROMPT, build_batch_user_prompt
+from utils.sentiment_prompt import SYSTEM_PROMPT, build_user_prompt
 from utils.sentiment_schema import (
     ALLOWED_EMOTIONS,
+    POLARITIES,
     SentimentResult,
-    parse_sentiment_batch,
+    parse_sentiment_response,
+    parse_sentiment_result,
 )
 
 
-def test_system_prompt_lists_allowed_emotions():
+def test_system_prompt_lists_allowed_emotions_and_polarities():
     for emotion in ALLOWED_EMOTIONS:
         assert emotion in SYSTEM_PROMPT
+    for polarity in POLARITIES:
+        assert polarity in SYSTEM_PROMPT
 
 
-def test_build_batch_user_prompt_includes_message_ids():
-    prompt = build_batch_user_prompt(
-        [
-            {
-                "message_id": "111",
-                "channel_name": "general",
-                "context_text": ">>> TARGET [alice] hello",
-            }
-        ]
+def test_build_user_prompt_includes_message_id():
+    prompt = build_user_prompt(
+        {
+            "message_id": "111",
+            "channel_name": "general",
+            "context_text": ">>> TARGET [alice] hello",
+        }
     )
     assert "message_id: 111" in prompt
     assert "#general" in prompt
+    assert ">>> TARGET [alice] hello" in prompt
 
 
 def test_format_context_block_marks_target():
@@ -57,12 +61,6 @@ def test_sentiment_model_default_and_override(monkeypatch):
     assert sentiment_job.sentiment_model() == "grok-build-0.1"
 
 
-def test_iter_batches():
-    items = [{"message_id": str(i)} for i in range(10)]
-    batches = sentiment_job.iter_batches(items, 4)
-    assert [len(b) for b in batches] == [4, 4, 2]
-
-
 def test_upsert_results_writes_rows():
     result = SentimentResult(
         message_id="123",
@@ -86,7 +84,7 @@ def test_upsert_results_writes_rows():
     assert rows[0][9] == "grok-4.3"
 
 
-def test_run_sentiment_nightly_scores_and_upserts(monkeypatch):
+def test_run_sentiment_nightly_scores_one_at_a_time(monkeypatch):
     monkeypatch.setenv("XAI_API_KEY", "xai-test")
     unscored = pd.DataFrame(
         [
@@ -101,46 +99,114 @@ def test_run_sentiment_nightly_scores_and_upserts(monkeypatch):
             }
         ]
     )
-    scored = [
-        SentimentResult(
-            message_id="99",
-            polarity="positive",
-            polarity_score=0.4,
-            emotions=["amusement"],
-            sarcasm=False,
-            toxicity="none",
-            directed_at="topic",
-            confidence=0.8,
-            rationale="Casual cheer",
-        )
-    ]
+    scored = SentimentResult(
+        message_id="99",
+        polarity="positive",
+        polarity_score=0.4,
+        emotions=["amusement"],
+        sarcasm=False,
+        toxicity="none",
+        directed_at="topic",
+        confidence=0.8,
+        rationale="Casual cheer",
+    )
 
-    with patch.object(sentiment_job, "ensure_sentiment_table"):
-        with patch.object(sentiment_job, "fetch_unscored_messages", return_value=unscored):
-            with patch.object(
-                sentiment_job,
-                "build_prompt_items",
-                return_value=[
-                    {
-                        "message_id": "99",
-                        "channel_name": "general",
-                        "context_text": ">>> TARGET [alice] gg",
-                    }
-                ],
-            ):
+    with patch.object(sentiment_job, "Client"):
+        with patch.object(sentiment_job, "ensure_sentiment_table"):
+            with patch.object(sentiment_job, "fetch_unscored_messages", return_value=unscored):
                 with patch.object(
-                    sentiment_job, "score_batch_with_grok", return_value=scored
-                ) as score:
-                    with patch.object(sentiment_job, "upsert_results", return_value=1) as upsert:
-                        written = sentiment_job.run_sentiment_nightly(limit=1)
+                    sentiment_job,
+                    "build_prompt_items",
+                    return_value=[
+                        {
+                            "message_id": "99",
+                            "channel_name": "general",
+                            "context_text": ">>> TARGET [alice] gg",
+                        }
+                    ],
+                ):
+                    with patch.object(
+                        sentiment_job, "score_message_with_grok", return_value=scored
+                    ) as score:
+                        with patch.object(sentiment_job, "upsert_results", return_value=1) as upsert:
+                            written = sentiment_job.run_sentiment_nightly(limit=1)
 
     assert written == 1
     score.assert_called_once()
     assert score.call_args.kwargs["model"] == "grok-4.3"
-    upsert.assert_called_once_with(scored, model="grok-4.3")
+    upsert.assert_called_once_with([scored], model="grok-4.3")
 
 
-def test_parse_sentiment_batch_round_trip():
+def test_run_sentiment_nightly_continues_after_failure(monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+    unscored = pd.DataFrame(
+        [
+            {
+                "message_id": mid,
+                "member_id": "1",
+                "channel_id": 2,
+                "content": "hi",
+                "created_at": pd.Timestamp("2026-07-20"),
+                "author_name": "alice",
+                "channel_name": "general",
+            }
+            for mid in (1, 2)
+        ]
+    )
+    ok = SentimentResult(
+        message_id="2",
+        polarity="neutral",
+        polarity_score=0.0,
+        emotions=["neutral"],
+        sarcasm=False,
+        toxicity="none",
+        directed_at="general",
+        confidence=0.5,
+        rationale="Flat",
+    )
+
+    def _score(item, *, model, client=None):
+        if item["message_id"] == "1":
+            raise RuntimeError("boom")
+        return ok
+
+    with patch.object(sentiment_job, "Client"):
+        with patch.object(sentiment_job, "ensure_sentiment_table"):
+            with patch.object(sentiment_job, "fetch_unscored_messages", return_value=unscored):
+                with patch.object(
+                    sentiment_job,
+                    "build_prompt_items",
+                    return_value=[
+                        {"message_id": "1", "channel_name": "general", "context_text": "t1"},
+                        {"message_id": "2", "channel_name": "general", "context_text": "t2"},
+                    ],
+                ):
+                    with patch.object(sentiment_job, "score_message_with_grok", side_effect=_score):
+                        with patch.object(sentiment_job, "upsert_results", return_value=1) as upsert:
+                            written = sentiment_job.run_sentiment_nightly()
+
+    assert written == 1
+    upsert.assert_called_once_with([ok], model="grok-4.3")
+
+
+def test_parse_sentiment_response_single_object():
+    payload = {
+        "message_id": "42",
+        "polarity": "neutral",
+        "polarity_score": 0.0,
+        "emotions": ["neutral"],
+        "sarcasm": False,
+        "toxicity": "none",
+        "directed_at": "general",
+        "confidence": 0.7,
+        "rationale": "No clear valence",
+    }
+    parsed = parse_sentiment_response(payload)
+    assert parsed.message_id == "42"
+    assert parsed.polarity == "neutral"
+
+
+def test_parse_sentiment_response_legacy_results_wrapper():
     payload = {
         "results": [
             {
@@ -156,9 +222,44 @@ def test_parse_sentiment_batch_round_trip():
             }
         ]
     }
-    parsed = parse_sentiment_batch(payload)
-    assert parsed[0].message_id == "42"
-    assert parsed[0].polarity == "neutral"
+    parsed = parse_sentiment_response(payload)
+    assert parsed.message_id == "42"
+
+
+def test_coerce_emotion_used_as_polarity():
+    result = parse_sentiment_result(
+        {
+            "message_id": "7",
+            "polarity": "surprise",
+            "polarity_score": 0.1,
+            "emotions": ["joy"],
+            "sarcasm": False,
+            "toxicity": "none",
+            "directed_at": "general",
+            "confidence": 0.8,
+            "rationale": "Unexpected twist",
+        }
+    )
+    assert result.polarity == "neutral"
+    assert result.emotions[0] == "surprise"
+    assert "joy" in result.emotions
+
+
+def test_invalid_polarity_still_raises():
+    with pytest.raises(ValueError, match="invalid polarity"):
+        parse_sentiment_result(
+            {
+                "message_id": "7",
+                "polarity": "ecstatic",
+                "polarity_score": 0.9,
+                "emotions": ["joy"],
+                "sarcasm": False,
+                "toxicity": "none",
+                "directed_at": "general",
+                "confidence": 0.8,
+                "rationale": "Too happy",
+            }
+        )
 
 
 def test_sentiment_cog_starts_when_api_key_present(monkeypatch):

--- a/utils/sentiment_job.py
+++ b/utils/sentiment_job.py
@@ -18,8 +18,8 @@ from xai_sdk import Client
 from xai_sdk.chat import system, user
 
 from utils.db import db_ops
-from utils.sentiment_prompt import SYSTEM_PROMPT, build_batch_user_prompt
-from utils.sentiment_schema import SentimentResult, parse_sentiment_batch
+from utils.sentiment_prompt import SYSTEM_PROMPT, build_user_prompt
+from utils.sentiment_schema import SentimentResult, parse_sentiment_response
 
 load_dotenv()
 
@@ -27,10 +27,10 @@ logger = logging.getLogger(__name__)
 
 # grok-4.3 + reasoning_effort=none is the cheap chat path after fast-model retirement.
 DEFAULT_SENTIMENT_MODEL = "grok-4.3"
-DEFAULT_BATCH_SIZE = 15
 DEFAULT_CONTEXT_SIZE = 3
 DEFAULT_MAX_CONTENT_CHARS = 500
 DEFAULT_MAX_RETRIES = 3
+PROGRESS_EVERY = 25
 
 ENSURE_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS message_sentiment (
@@ -53,6 +53,7 @@ CREATE TABLE IF NOT EXISTS message_sentiment (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
 """
 
+# Newest first so recent holes are filled before ancient backfill gaps.
 UNSCORED_SQL = """
 SELECT
     m.id AS message_id,
@@ -69,7 +70,7 @@ LEFT JOIN message_sentiment s ON s.message_id = m.id
 WHERE s.message_id IS NULL
   AND m.content IS NOT NULL
   AND TRIM(m.content) <> ''
-ORDER BY m.channel_id, m.created_at, m.id
+ORDER BY m.created_at DESC, m.id DESC
 """
 
 PRIORS_SQL = """
@@ -215,24 +216,22 @@ def build_prompt_items(
     return items
 
 
-def iter_batches(items: list[dict], batch_size: int) -> list[list[dict]]:
-    return [items[i : i + batch_size] for i in range(0, len(items), batch_size)]
-
-
-def score_batch_with_grok(
-    items: list[dict],
+def score_message_with_grok(
+    item: dict,
     *,
     model: str,
+    client: Client | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
-) -> list[SentimentResult]:
-    """Score one batch via Grok structured JSON (no tools / no reasoning)."""
-    api_key = os.getenv("XAI_API_KEY", "").strip()
-    if not api_key:
-        raise RuntimeError("XAI_API_KEY is required for sentiment scoring")
+) -> SentimentResult:
+    """Score one message via Grok structured JSON (no tools / no reasoning)."""
+    if client is None:
+        api_key = os.getenv("XAI_API_KEY", "").strip()
+        if not api_key:
+            raise RuntimeError("XAI_API_KEY is required for sentiment scoring")
+        client = Client(api_key=api_key, timeout=120)
 
-    client = Client(api_key=api_key, timeout=600)
-    user_prompt = build_batch_user_prompt(items)
-    expected_ids = {item["message_id"] for item in items}
+    user_prompt = build_user_prompt(item)
+    expected_id = item["message_id"]
     last_error: Exception | None = None
 
     for attempt in range(max_retries):
@@ -247,24 +246,26 @@ def score_batch_with_grok(
             chat.append(system(SYSTEM_PROMPT))
             chat.append(user(user_prompt))
             response = chat.sample()
-            parsed = parse_sentiment_batch(json.loads(response.content))
-            results = [r for r in parsed if r.message_id in expected_ids]
-            got_ids = {r.message_id for r in results}
-            missing = expected_ids - got_ids
-            if missing:
-                raise ValueError(f"Model omitted message_ids: {sorted(missing)[:5]}")
-            return results
+            result = parse_sentiment_response(json.loads(response.content))
+            if result.message_id != expected_id:
+                raise ValueError(
+                    f"Model returned message_id={result.message_id!r}, expected {expected_id!r}"
+                )
+            return result
         except Exception as exc:  # noqa: BLE001 — retry transient/parse failures
             last_error = exc
             logger.warning(
-                "Sentiment batch attempt %s/%s failed: %s",
+                "Sentiment attempt %s/%s failed for message_id=%s: %s",
                 attempt + 1,
                 max_retries,
+                expected_id,
                 exc,
             )
             time.sleep(1.5 * (attempt + 1))
 
-    raise RuntimeError(f"Sentiment batch failed after {max_retries} attempts: {last_error}")
+    raise RuntimeError(
+        f"Sentiment failed for message_id={expected_id} after {max_retries} attempts: {last_error}"
+    )
 
 
 def upsert_results(results: list[SentimentResult], *, model: str) -> int:
@@ -300,6 +301,9 @@ def run_sentiment_nightly(*, limit: int | None = None) -> int:
     """
     Score unscored messages with Grok and upsert into message_sentiment.
 
+    Scores one message at a time (newest first). Individual failures are logged
+    and skipped so one bad response cannot abort the whole run.
+
     Returns number of rows written.
     """
     if not sentiment_enabled():
@@ -310,8 +314,9 @@ def run_sentiment_nightly(*, limit: int | None = None) -> int:
         if raw:
             limit = int(raw)
 
-    batch_size = int(os.getenv("SENTIMENT_BATCH_SIZE", str(DEFAULT_BATCH_SIZE)))
     model = sentiment_model()
+    api_key = os.getenv("XAI_API_KEY", "").strip()
+    client = Client(api_key=api_key, timeout=120)
 
     ensure_sentiment_table()
     unscored = fetch_unscored_messages(limit=limit)
@@ -323,9 +328,22 @@ def run_sentiment_nightly(*, limit: int | None = None) -> int:
     logger.info("Scoring %s unscored messages with %s...", len(items), model)
 
     written = 0
-    for batch in iter_batches(items, batch_size):
-        results = score_batch_with_grok(batch, model=model)
-        written += upsert_results(results, model=model)
+    failures = 0
+    for i, item in enumerate(items, start=1):
+        try:
+            result = score_message_with_grok(item, model=model, client=client)
+            written += upsert_results([result], model=model)
+        except Exception:
+            failures += 1
+            logger.exception("Sentiment failed for message_id=%s", item["message_id"])
+        if i % PROGRESS_EVERY == 0 or i == len(items):
+            logger.info(
+                "Sentiment progress %s/%s (written=%s, failures=%s)",
+                i,
+                len(items),
+                written,
+                failures,
+            )
 
-    logger.info("Upserted %s sentiment rows", written)
+    logger.info("Upserted %s sentiment rows (%s failures)", written, failures)
     return written

--- a/utils/sentiment_prompt.py
+++ b/utils/sentiment_prompt.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-from utils.sentiment_schema import ALLOWED_EMOTIONS
+from utils.sentiment_schema import ALLOWED_EMOTIONS, POLARITIES
 
 SYSTEM_PROMPT = f"""You are analyzing Discord chat messages for sentiment.
 
-For each item, score ONLY the message marked >>> TARGET.
+Score ONLY the message marked >>> TARGET.
 Use the preceding messages solely as local context (sarcasm, irony, in-jokes, replies).
 
-Return JSON with a top-level "results" array. Each element must include:
-- message_id (string, copy exactly from the item)
-- polarity: positive | negative | neutral | mixed
+Return a single JSON object (not an array) with:
+- message_id (string, copy exactly from the input)
+- polarity: one of {", ".join(sorted(POLARITIES))} — never an emotion label
 - polarity_score: float from -1 (very negative) to 1 (very positive); mixed near 0
 - emotions: 1–3 labels from this fixed set only: {", ".join(sorted(ALLOWED_EMOTIONS))}
 - sarcasm: boolean (true if ironic / sarcastic given context)
@@ -21,27 +21,21 @@ Return JSON with a top-level "results" array. Each element must include:
 - rationale: at most 15 words
 
 Rules:
+- polarity and emotions are different fields; do not put emotion names in polarity.
 - Short Discord slang (lol, lmao, gg) can still carry clear polarity.
 - Prefer sarcasm=true when surface polarity conflicts with context.
 - Keep rationales terse; do not quote long message text.
-- Output one result per input item, same order, same message_ids.
 """
 
 
-def build_batch_user_prompt(items: list[dict]) -> str:
-    """Build the user prompt for a batch of targets.
+def build_user_prompt(item: dict) -> str:
+    """Build the user prompt for one target message.
 
-    Each item needs: message_id, channel_name, context_text
+    Item needs: message_id, channel_name, context_text
     """
-    blocks: list[str] = [
-        f"Analyze {len(items)} Discord message(s). "
-        'Return JSON {"results": [...]} with one object per item.\n'
-    ]
-    for idx, item in enumerate(items, start=1):
-        blocks.append(
-            f"--- ITEM {idx} ---\n"
-            f"message_id: {item['message_id']}\n"
-            f"channel: #{item.get('channel_name', 'unknown')}\n"
-            f"{item['context_text']}\n"
-        )
-    return "\n".join(blocks)
+    return (
+        "Analyze this Discord message. Return one JSON object.\n\n"
+        f"message_id: {item['message_id']}\n"
+        f"channel: #{item.get('channel_name', 'unknown')}\n"
+        f"{item['context_text']}\n"
+    )

--- a/utils/sentiment_schema.py
+++ b/utils/sentiment_schema.py
@@ -45,9 +45,32 @@ def _shorten_rationale(value: str) -> str:
     return value.strip()
 
 
-def _clean_emotions(values: Any) -> list[str]:
-    if not isinstance(values, list) or not values:
-        raise ValueError("emotions must be a non-empty list")
+def _polarity_from_score(polarity_score: float) -> str:
+    if polarity_score > 0.25:
+        return "positive"
+    if polarity_score < -0.25:
+        return "negative"
+    return "neutral"
+
+
+def _coerce_polarity(raw_polarity: Any, polarity_score: float) -> tuple[str, str | None]:
+    """Return (polarity, emotion_to_merge_or_None).
+
+    Models sometimes put an emotion label in the polarity field.
+    """
+    polarity = str(raw_polarity or "").strip().lower()
+    if polarity in POLARITIES:
+        return polarity, None
+    if polarity in ALLOWED_EMOTIONS:
+        return _polarity_from_score(polarity_score), polarity
+    raise ValueError(f"invalid polarity: {polarity!r}")
+
+
+def _clean_emotions(values: Any, *, extra: str | None = None) -> list[str]:
+    if values is None:
+        values = []
+    if not isinstance(values, list):
+        raise ValueError("emotions must be a list")
     cleaned: list[str] = []
     for emotion in values:
         key = str(emotion).strip().lower()
@@ -55,8 +78,10 @@ def _clean_emotions(values: Any) -> list[str]:
             raise ValueError(f"emotion '{emotion}' not in {sorted(ALLOWED_EMOTIONS)}")
         if key not in cleaned:
             cleaned.append(key)
+    if extra and extra in ALLOWED_EMOTIONS and extra not in cleaned:
+        cleaned.insert(0, extra)
     if not cleaned:
-        raise ValueError("emotions must contain at least one label")
+        cleaned = ["neutral"]
     return cleaned[:3]
 
 
@@ -68,9 +93,11 @@ def parse_sentiment_result(raw: Any) -> SentimentResult:
     if not message_id:
         raise ValueError("message_id is required")
 
-    polarity = str(raw.get("polarity", "")).strip().lower()
-    if polarity not in POLARITIES:
-        raise ValueError(f"invalid polarity: {polarity!r}")
+    polarity_score = float(raw["polarity_score"])
+    if polarity_score < -1.0 or polarity_score > 1.0:
+        raise ValueError(f"polarity_score out of range: {polarity_score}")
+
+    polarity, emotion_from_polarity = _coerce_polarity(raw.get("polarity"), polarity_score)
 
     toxicity = str(raw.get("toxicity", "")).strip().lower()
     if toxicity not in TOXICITIES:
@@ -80,10 +107,6 @@ def parse_sentiment_result(raw: Any) -> SentimentResult:
     if directed_at not in DIRECTED_ATS:
         raise ValueError(f"invalid directed_at: {directed_at!r}")
 
-    polarity_score = float(raw["polarity_score"])
-    if polarity_score < -1.0 or polarity_score > 1.0:
-        raise ValueError(f"polarity_score out of range: {polarity_score}")
-
     confidence = float(raw["confidence"])
     if confidence < 0.0 or confidence > 1.0:
         raise ValueError(f"confidence out of range: {confidence}")
@@ -92,7 +115,7 @@ def parse_sentiment_result(raw: Any) -> SentimentResult:
         message_id=message_id,
         polarity=polarity,
         polarity_score=polarity_score,
-        emotions=_clean_emotions(raw.get("emotions")),
+        emotions=_clean_emotions(raw.get("emotions"), extra=emotion_from_polarity),
         sarcasm=bool(raw.get("sarcasm")),
         toxicity=toxicity,
         directed_at=directed_at,
@@ -101,12 +124,15 @@ def parse_sentiment_result(raw: Any) -> SentimentResult:
     )
 
 
-def parse_sentiment_batch(payload: Any) -> list[SentimentResult]:
+def parse_sentiment_response(payload: Any) -> SentimentResult:
+    """Parse a single-message model response (object or legacy {{results: [...]}})."""
     if isinstance(payload, str):
         payload = json.loads(payload)
     if not isinstance(payload, dict):
-        raise ValueError("batch response must be an object")
-    results = payload.get("results")
-    if not isinstance(results, list) or not results:
-        raise ValueError("results must be a non-empty list")
-    return [parse_sentiment_result(item) for item in results]
+        raise ValueError("response must be an object")
+    if "results" in payload:
+        results = payload.get("results")
+        if not isinstance(results, list) or len(results) != 1:
+            raise ValueError("results must be a single-item list")
+        return parse_sentiment_result(results[0])
+    return parse_sentiment_result(payload)


### PR DESCRIPTION
## Summary
- Scores sentiment **one message at a time** (no batches), newest unscored first
- Continues past individual Grok/JSON/schema failures instead of aborting the whole run
- Coerces emotion-as-polarity mistakes (e.g. `surprise`) using `polarity_score`, and clarifies the prompt

## Context
A manual run tried ~14.5k historical holes and died after ~1 hour on batch JSON parse errors and `invalid polarity: 'surprise'`.

## Test plan
- [ ] `pytest tests/test_sentiment_job.py`
- [ ] `/score_sentiment limit:20` completes and writes rows
- [ ] Confirm logs show per-message progress and skipped failures do not stop the run
- [ ] Optional: set `SENTIMENT_NIGHTLY_LIMIT=500` while clearing backlog
