### PR TITLE
Restore resilient batch scoring for nightly sentiment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,5 @@ DINK_MINT_AMOUNT=1
 # GROK_SENTIMENT_MODEL=grok-4.3
 # Optional cap per run (newest unscored first; useful while catching up historical holes)
 # SENTIMENT_NIGHTLY_LIMIT=500
+# Messages per Grok request (falls back to per-message scoring if a batch response is bad)
+# SENTIMENT_BATCH_SIZE=10

--- a/tests/test_sentiment_job.py
+++ b/tests/test_sentiment_job.py
@@ -7,14 +7,29 @@ import pytest
 
 from cogs.sentiment import Sentiment
 from utils import sentiment_job
-from utils.sentiment_prompt import SYSTEM_PROMPT, build_user_prompt
+from utils.sentiment_prompt import SYSTEM_PROMPT, build_batch_user_prompt, build_user_prompt
 from utils.sentiment_schema import (
     ALLOWED_EMOTIONS,
     POLARITIES,
     SentimentResult,
+    parse_sentiment_batch_response,
     parse_sentiment_response,
     parse_sentiment_result,
 )
+
+
+def _result(message_id: str, *, polarity: str = "neutral") -> SentimentResult:
+    return SentimentResult(
+        message_id=message_id,
+        polarity=polarity,
+        polarity_score=0.0 if polarity == "neutral" else 0.4,
+        emotions=["neutral"] if polarity == "neutral" else ["amusement"],
+        sarcasm=False,
+        toxicity="none",
+        directed_at="general",
+        confidence=0.8,
+        rationale="Test result",
+    )
 
 
 def test_system_prompt_lists_allowed_emotions_and_polarities():
@@ -35,6 +50,28 @@ def test_build_user_prompt_includes_message_id():
     assert "message_id: 111" in prompt
     assert "#general" in prompt
     assert ">>> TARGET [alice] hello" in prompt
+
+
+def test_build_batch_user_prompt_includes_all_items():
+    prompt = build_batch_user_prompt(
+        [
+            {
+                "message_id": "111",
+                "channel_name": "general",
+                "context_text": ">>> TARGET [alice] hello",
+            },
+            {
+                "message_id": "222",
+                "channel_name": "memes",
+                "context_text": ">>> TARGET [bob] lol",
+            },
+        ]
+    )
+    assert 'Return JSON {"results": [...]}' in prompt
+    assert "message_id: 111" in prompt
+    assert "message_id: 222" in prompt
+    assert "#memes" in prompt
+    assert "--- ITEM 2 ---" in prompt
 
 
 def test_format_context_block_marks_target():
@@ -61,6 +98,26 @@ def test_sentiment_model_default_and_override(monkeypatch):
     assert sentiment_job.sentiment_model() == "grok-build-0.1"
 
 
+def test_sentiment_batch_size_default_and_override(monkeypatch):
+    monkeypatch.delenv("SENTIMENT_BATCH_SIZE", raising=False)
+    assert sentiment_job.sentiment_batch_size() == 10
+    monkeypatch.setenv("SENTIMENT_BATCH_SIZE", "5")
+    assert sentiment_job.sentiment_batch_size() == 5
+
+
+def test_sentiment_batch_size_rejects_invalid(monkeypatch):
+    monkeypatch.setenv("SENTIMENT_BATCH_SIZE", "nope")
+    assert sentiment_job.sentiment_batch_size() == 10
+    monkeypatch.setenv("SENTIMENT_BATCH_SIZE", "0")
+    assert sentiment_job.sentiment_batch_size() == 10
+
+
+def test_iter_batches_splits_items():
+    items = [{"message_id": str(i)} for i in range(5)]
+    batches = sentiment_job.iter_batches(items, 2)
+    assert batches == [items[0:2], items[2:4], items[4:5]]
+
+
 def test_upsert_results_writes_rows():
     result = SentimentResult(
         message_id="123",
@@ -84,12 +141,13 @@ def test_upsert_results_writes_rows():
     assert rows[0][9] == "grok-4.3"
 
 
-def test_run_sentiment_nightly_scores_one_at_a_time(monkeypatch):
+def test_run_sentiment_nightly_scores_in_batches(monkeypatch):
     monkeypatch.setenv("XAI_API_KEY", "xai-test")
+    monkeypatch.setenv("SENTIMENT_BATCH_SIZE", "2")
     unscored = pd.DataFrame(
         [
             {
-                "message_id": 99,
+                "message_id": mid,
                 "member_id": "1",
                 "channel_id": 2,
                 "content": "gg",
@@ -97,48 +155,45 @@ def test_run_sentiment_nightly_scores_one_at_a_time(monkeypatch):
                 "author_name": "alice",
                 "channel_name": "general",
             }
+            for mid in (99, 100, 101)
         ]
     )
-    scored = SentimentResult(
-        message_id="99",
-        polarity="positive",
-        polarity_score=0.4,
-        emotions=["amusement"],
-        sarcasm=False,
-        toxicity="none",
-        directed_at="topic",
-        confidence=0.8,
-        rationale="Casual cheer",
-    )
+    items = [
+        {"message_id": "99", "channel_name": "general", "context_text": "t99"},
+        {"message_id": "100", "channel_name": "general", "context_text": "t100"},
+        {"message_id": "101", "channel_name": "general", "context_text": "t101"},
+    ]
+    scored_batches = [
+        [_result("99", polarity="positive"), _result("100", polarity="positive")],
+        [_result("101", polarity="positive")],
+    ]
 
     with patch.object(sentiment_job, "Client"):
         with patch.object(sentiment_job, "ensure_sentiment_table"):
             with patch.object(sentiment_job, "fetch_unscored_messages", return_value=unscored):
-                with patch.object(
-                    sentiment_job,
-                    "build_prompt_items",
-                    return_value=[
-                        {
-                            "message_id": "99",
-                            "channel_name": "general",
-                            "context_text": ">>> TARGET [alice] gg",
-                        }
-                    ],
-                ):
+                with patch.object(sentiment_job, "build_prompt_items", return_value=items):
                     with patch.object(
-                        sentiment_job, "score_message_with_grok", return_value=scored
-                    ) as score:
-                        with patch.object(sentiment_job, "upsert_results", return_value=1) as upsert:
-                            written = sentiment_job.run_sentiment_nightly(limit=1)
+                        sentiment_job,
+                        "score_batch_with_grok",
+                        side_effect=scored_batches,
+                    ) as score_batch:
+                        with patch.object(
+                            sentiment_job, "upsert_results", side_effect=[2, 1]
+                        ) as upsert:
+                            written = sentiment_job.run_sentiment_nightly(limit=3)
 
-    assert written == 1
-    score.assert_called_once()
-    assert score.call_args.kwargs["model"] == "grok-4.3"
-    upsert.assert_called_once_with([scored], model="grok-4.3")
+    assert written == 3
+    assert score_batch.call_count == 2
+    assert score_batch.call_args_list[0].args[0] == items[:2]
+    assert score_batch.call_args_list[1].args[0] == items[2:]
+    assert upsert.call_count == 2
+    upsert.assert_any_call(scored_batches[0], model="grok-4.3")
+    upsert.assert_any_call(scored_batches[1], model="grok-4.3")
 
 
-def test_run_sentiment_nightly_continues_after_failure(monkeypatch):
+def test_run_sentiment_nightly_continues_after_batch_failure(monkeypatch):
     monkeypatch.setenv("XAI_API_KEY", "xai-test")
+    monkeypatch.setenv("SENTIMENT_BATCH_SIZE", "1")
     unscored = pd.DataFrame(
         [
             {
@@ -153,22 +208,12 @@ def test_run_sentiment_nightly_continues_after_failure(monkeypatch):
             for mid in (1, 2)
         ]
     )
-    ok = SentimentResult(
-        message_id="2",
-        polarity="neutral",
-        polarity_score=0.0,
-        emotions=["neutral"],
-        sarcasm=False,
-        toxicity="none",
-        directed_at="general",
-        confidence=0.5,
-        rationale="Flat",
-    )
+    ok = _result("2")
 
-    def _score(item, *, model, client=None):
-        if item["message_id"] == "1":
+    def _score(batch, *, model, client=None):
+        if batch[0]["message_id"] == "1":
             raise RuntimeError("boom")
-        return ok
+        return [ok]
 
     with patch.object(sentiment_job, "Client"):
         with patch.object(sentiment_job, "ensure_sentiment_table"):
@@ -181,12 +226,70 @@ def test_run_sentiment_nightly_continues_after_failure(monkeypatch):
                         {"message_id": "2", "channel_name": "general", "context_text": "t2"},
                     ],
                 ):
-                    with patch.object(sentiment_job, "score_message_with_grok", side_effect=_score):
+                    with patch.object(sentiment_job, "score_batch_with_grok", side_effect=_score):
                         with patch.object(sentiment_job, "upsert_results", return_value=1) as upsert:
                             written = sentiment_job.run_sentiment_nightly()
 
     assert written == 1
     upsert.assert_called_once_with([ok], model="grok-4.3")
+
+
+def test_score_batch_with_grok_falls_back_to_singles(monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+    items = [
+        {"message_id": "1", "channel_name": "general", "context_text": "t1"},
+        {"message_id": "2", "channel_name": "general", "context_text": "t2"},
+    ]
+    ok1 = _result("1", polarity="positive")
+    ok2 = _result("2")
+
+    with patch.object(
+        sentiment_job,
+        "_score_batch_once",
+        side_effect=ValueError("bad json"),
+    ) as batch_once:
+        with patch.object(
+            sentiment_job,
+            "score_message_with_grok",
+            side_effect=[ok1, ok2],
+        ) as score_one:
+            with patch.object(sentiment_job.time, "sleep"):
+                results = sentiment_job.score_batch_with_grok(
+                    items,
+                    model="grok-4.3",
+                    client=MagicMock(),
+                    max_retries=2,
+                )
+
+    assert results == [ok1, ok2]
+    assert batch_once.call_count == 2
+    assert score_one.call_count == 2
+
+
+def test_score_batch_with_grok_skips_failed_fallback_items(monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+    items = [
+        {"message_id": "1", "channel_name": "general", "context_text": "t1"},
+        {"message_id": "2", "channel_name": "general", "context_text": "t2"},
+    ]
+    ok2 = _result("2")
+
+    def _score_one(item, *, model, client=None, max_retries=3):
+        if item["message_id"] == "1":
+            raise RuntimeError("still bad")
+        return ok2
+
+    with patch.object(sentiment_job, "_score_batch_once", side_effect=ValueError("bad json")):
+        with patch.object(sentiment_job, "score_message_with_grok", side_effect=_score_one):
+            with patch.object(sentiment_job.time, "sleep"):
+                results = sentiment_job.score_batch_with_grok(
+                    items,
+                    model="grok-4.3",
+                    client=MagicMock(),
+                    max_retries=1,
+                )
+
+    assert results == [ok2]
 
 
 def test_parse_sentiment_response_single_object():
@@ -224,6 +327,88 @@ def test_parse_sentiment_response_legacy_results_wrapper():
     }
     parsed = parse_sentiment_response(payload)
     assert parsed.message_id == "42"
+
+
+def test_parse_sentiment_batch_response_validates_coverage():
+    payload = {
+        "results": [
+            {
+                "message_id": "1",
+                "polarity": "positive",
+                "polarity_score": 0.5,
+                "emotions": ["joy"],
+                "sarcasm": False,
+                "toxicity": "none",
+                "directed_at": "general",
+                "confidence": 0.9,
+                "rationale": "Upbeat",
+            },
+            {
+                "message_id": "2",
+                "polarity": "neutral",
+                "polarity_score": 0.0,
+                "emotions": ["neutral"],
+                "sarcasm": False,
+                "toxicity": "none",
+                "directed_at": "general",
+                "confidence": 0.7,
+                "rationale": "Flat",
+            },
+        ]
+    }
+    parsed = parse_sentiment_batch_response(payload, expected_ids={"1", "2"})
+    assert [r.message_id for r in parsed] == ["1", "2"]
+
+
+def test_parse_sentiment_batch_response_rejects_missing_ids():
+    payload = {
+        "results": [
+            {
+                "message_id": "1",
+                "polarity": "neutral",
+                "polarity_score": 0.0,
+                "emotions": ["neutral"],
+                "sarcasm": False,
+                "toxicity": "none",
+                "directed_at": "general",
+                "confidence": 0.7,
+                "rationale": "Only one",
+            }
+        ]
+    }
+    with pytest.raises(ValueError, match="omitted message_ids"):
+        parse_sentiment_batch_response(payload, expected_ids={"1", "2"})
+
+
+def test_parse_sentiment_batch_response_rejects_duplicates():
+    payload = {
+        "results": [
+            {
+                "message_id": "1",
+                "polarity": "neutral",
+                "polarity_score": 0.0,
+                "emotions": ["neutral"],
+                "sarcasm": False,
+                "toxicity": "none",
+                "directed_at": "general",
+                "confidence": 0.7,
+                "rationale": "First",
+            },
+            {
+                "message_id": "1",
+                "polarity": "positive",
+                "polarity_score": 0.4,
+                "emotions": ["joy"],
+                "sarcasm": False,
+                "toxicity": "none",
+                "directed_at": "general",
+                "confidence": 0.8,
+                "rationale": "Dup",
+            },
+        ]
+    }
+    with pytest.raises(ValueError, match="duplicate message_ids"):
+        parse_sentiment_batch_response(payload, expected_ids={"1", "2"})
 
 
 def test_coerce_emotion_used_as_polarity():

--- a/utils/sentiment_job.py
+++ b/utils/sentiment_job.py
@@ -18,8 +18,12 @@ from xai_sdk import Client
 from xai_sdk.chat import system, user
 
 from utils.db import db_ops
-from utils.sentiment_prompt import SYSTEM_PROMPT, build_user_prompt
-from utils.sentiment_schema import SentimentResult, parse_sentiment_response
+from utils.sentiment_prompt import SYSTEM_PROMPT, build_batch_user_prompt, build_user_prompt
+from utils.sentiment_schema import (
+    SentimentResult,
+    parse_sentiment_batch_response,
+    parse_sentiment_response,
+)
 
 load_dotenv()
 
@@ -27,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 # grok-4.3 + reasoning_effort=none is the cheap chat path after fast-model retirement.
 DEFAULT_SENTIMENT_MODEL = "grok-4.3"
+DEFAULT_BATCH_SIZE = 10
 DEFAULT_CONTEXT_SIZE = 3
 DEFAULT_MAX_CONTENT_CHARS = 500
 DEFAULT_MAX_RETRIES = 3
@@ -120,6 +125,27 @@ def sentiment_enabled() -> bool:
     return bool(os.getenv("XAI_API_KEY", "").strip())
 
 
+def sentiment_batch_size() -> int:
+    raw = os.getenv("SENTIMENT_BATCH_SIZE", str(DEFAULT_BATCH_SIZE)).strip()
+    try:
+        size = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid SENTIMENT_BATCH_SIZE=%r; using %s",
+            raw,
+            DEFAULT_BATCH_SIZE,
+        )
+        return DEFAULT_BATCH_SIZE
+    if size < 1:
+        logger.warning(
+            "SENTIMENT_BATCH_SIZE=%s must be >= 1; using %s",
+            size,
+            DEFAULT_BATCH_SIZE,
+        )
+        return DEFAULT_BATCH_SIZE
+    return size
+
+
 def _truncate(text: str, max_chars: int) -> str:
     text = text.replace("\n", " ").strip()
     if len(text) <= max_chars:
@@ -148,11 +174,12 @@ def ensure_sentiment_table() -> None:
 
 
 def fetch_unscored_messages(limit: int | None = None) -> pd.DataFrame:
-    df = db_ops.db.fetch_df(UNSCORED_SQL)
+    if limit is not None:
+        df = db_ops.db.fetch_df(UNSCORED_SQL + " LIMIT %s", (int(limit),))
+    else:
+        df = db_ops.db.fetch_df(UNSCORED_SQL)
     if df.empty:
         return df
-    if limit is not None:
-        df = df.head(limit).copy()
     df["message_id"] = df["message_id"].astype("int64")
     df["created_at"] = pd.to_datetime(df["created_at"])
     df["content"] = df["content"].fillna("").astype(str)
@@ -216,6 +243,12 @@ def build_prompt_items(
     return items
 
 
+def iter_batches(items: list[dict], batch_size: int) -> list[list[dict]]:
+    if batch_size < 1:
+        raise ValueError("batch_size must be >= 1")
+    return [items[i : i + batch_size] for i in range(0, len(items), batch_size)]
+
+
 def score_message_with_grok(
     item: dict,
     *,
@@ -268,6 +301,94 @@ def score_message_with_grok(
     )
 
 
+def _score_batch_once(
+    items: list[dict],
+    *,
+    model: str,
+    client: Client,
+) -> list[SentimentResult]:
+    """Attempt a single batch call; raises on parse/coverage failure."""
+    user_prompt = build_batch_user_prompt(items)
+    expected_ids = {item["message_id"] for item in items}
+    chat = client.chat.create(
+        model=model,
+        temperature=0.2,
+        reasoning_effort="none",
+        response_format="json_object",
+        store_messages=False,
+    )
+    chat.append(system(SYSTEM_PROMPT))
+    chat.append(user(user_prompt))
+    response = chat.sample()
+    return parse_sentiment_batch_response(
+        json.loads(response.content),
+        expected_ids=expected_ids,
+    )
+
+
+def score_batch_with_grok(
+    items: list[dict],
+    *,
+    model: str,
+    client: Client | None = None,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> list[SentimentResult]:
+    """Score a batch via Grok.
+
+    Retries the batch call on transient/parse failures. If the batch still fails,
+    falls back to per-message scoring so one bad JSON payload cannot abort the run.
+    Individual fallback failures are logged and skipped.
+    """
+    if not items:
+        return []
+    if len(items) == 1:
+        return [score_message_with_grok(items[0], model=model, client=client, max_retries=max_retries)]
+
+    if client is None:
+        api_key = os.getenv("XAI_API_KEY", "").strip()
+        if not api_key:
+            raise RuntimeError("XAI_API_KEY is required for sentiment scoring")
+        client = Client(api_key=api_key, timeout=120)
+
+    last_error: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            return _score_batch_once(items, model=model, client=client)
+        except Exception as exc:  # noqa: BLE001 — retry transient/parse failures
+            last_error = exc
+            logger.warning(
+                "Sentiment batch attempt %s/%s failed (%s messages): %s",
+                attempt + 1,
+                max_retries,
+                len(items),
+                exc,
+            )
+            time.sleep(1.5 * (attempt + 1))
+
+    logger.warning(
+        "Sentiment batch failed after %s attempts (%s); falling back to per-message scoring",
+        max_retries,
+        last_error,
+    )
+    results: list[SentimentResult] = []
+    for item in items:
+        try:
+            results.append(
+                score_message_with_grok(
+                    item,
+                    model=model,
+                    client=client,
+                    max_retries=max_retries,
+                )
+            )
+        except Exception:
+            logger.exception(
+                "Sentiment fallback failed for message_id=%s",
+                item["message_id"],
+            )
+    return results
+
+
 def upsert_results(results: list[SentimentResult], *, model: str) -> int:
     if not results:
         return 0
@@ -301,8 +422,9 @@ def run_sentiment_nightly(*, limit: int | None = None) -> int:
     """
     Score unscored messages with Grok and upsert into message_sentiment.
 
-    Scores one message at a time (newest first). Individual failures are logged
-    and skipped so one bad response cannot abort the whole run.
+    Scores in batches (newest first). Malformed batch responses fall back to
+    per-message scoring; individual failures are logged and skipped so one bad
+    response cannot abort the whole run.
 
     Returns number of rows written.
     """
@@ -314,6 +436,7 @@ def run_sentiment_nightly(*, limit: int | None = None) -> int:
         if raw:
             limit = int(raw)
 
+    batch_size = sentiment_batch_size()
     model = sentiment_model()
     api_key = os.getenv("XAI_API_KEY", "").strip()
     client = Client(api_key=api_key, timeout=120)
@@ -325,24 +448,43 @@ def run_sentiment_nightly(*, limit: int | None = None) -> int:
         return 0
 
     items = build_prompt_items(unscored)
-    logger.info("Scoring %s unscored messages with %s...", len(items), model)
+    batches = iter_batches(items, batch_size)
+    logger.info(
+        "Scoring %s unscored messages with %s (batch_size=%s, batches=%s)...",
+        len(items),
+        model,
+        batch_size,
+        len(batches),
+    )
 
     written = 0
     failures = 0
-    for i, item in enumerate(items, start=1):
+    processed = 0
+    for batch_idx, batch in enumerate(batches, start=1):
         try:
-            result = score_message_with_grok(item, model=model, client=client)
-            written += upsert_results([result], model=model)
+            results = score_batch_with_grok(batch, model=model, client=client)
+            skipped = len(batch) - len(results)
+            if skipped > 0:
+                failures += skipped
+            written += upsert_results(results, model=model)
         except Exception:
-            failures += 1
-            logger.exception("Sentiment failed for message_id=%s", item["message_id"])
-        if i % PROGRESS_EVERY == 0 or i == len(items):
+            failures += len(batch)
+            logger.exception(
+                "Sentiment batch %s/%s failed entirely (%s messages)",
+                batch_idx,
+                len(batches),
+                len(batch),
+            )
+        processed += len(batch)
+        if processed % PROGRESS_EVERY < len(batch) or batch_idx == len(batches):
             logger.info(
-                "Sentiment progress %s/%s (written=%s, failures=%s)",
-                i,
+                "Sentiment progress %s/%s (written=%s, failures=%s, batch=%s/%s)",
+                processed,
                 len(items),
                 written,
                 failures,
+                batch_idx,
+                len(batches),
             )
 
     logger.info("Upserted %s sentiment rows (%s failures)", written, failures)

--- a/utils/sentiment_prompt.py
+++ b/utils/sentiment_prompt.py
@@ -9,7 +9,7 @@ SYSTEM_PROMPT = f"""You are analyzing Discord chat messages for sentiment.
 Score ONLY the message marked >>> TARGET.
 Use the preceding messages solely as local context (sarcasm, irony, in-jokes, replies).
 
-Return a single JSON object (not an array) with:
+For each scored message include:
 - message_id (string, copy exactly from the input)
 - polarity: one of {", ".join(sorted(POLARITIES))} — never an emotion label
 - polarity_score: float from -1 (very negative) to 1 (very positive); mixed near 0
@@ -25,6 +25,7 @@ Rules:
 - Short Discord slang (lol, lmao, gg) can still carry clear polarity.
 - Prefer sarcasm=true when surface polarity conflicts with context.
 - Keep rationales terse; do not quote long message text.
+- Output one result per input item, same order, same message_ids.
 """
 
 
@@ -39,3 +40,22 @@ def build_user_prompt(item: dict) -> str:
         f"channel: #{item.get('channel_name', 'unknown')}\n"
         f"{item['context_text']}\n"
     )
+
+
+def build_batch_user_prompt(items: list[dict]) -> str:
+    """Build the user prompt for a batch of targets.
+
+    Each item needs: message_id, channel_name, context_text
+    """
+    blocks: list[str] = [
+        f"Analyze {len(items)} Discord message(s). "
+        'Return JSON {"results": [...]} with one object per item.\n'
+    ]
+    for idx, item in enumerate(items, start=1):
+        blocks.append(
+            f"--- ITEM {idx} ---\n"
+            f"message_id: {item['message_id']}\n"
+            f"channel: #{item.get('channel_name', 'unknown')}\n"
+            f"{item['context_text']}\n"
+        )
+    return "\n".join(blocks)

--- a/utils/sentiment_schema.py
+++ b/utils/sentiment_schema.py
@@ -136,3 +136,38 @@ def parse_sentiment_response(payload: Any) -> SentimentResult:
             raise ValueError("results must be a single-item list")
         return parse_sentiment_result(results[0])
     return parse_sentiment_result(payload)
+
+
+def parse_sentiment_batch_response(
+    payload: Any,
+    *,
+    expected_ids: set[str] | None = None,
+) -> list[SentimentResult]:
+    """Parse a batch model response with a top-level results array."""
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    if not isinstance(payload, dict):
+        raise ValueError("response must be an object")
+
+    results_raw = payload.get("results")
+    if not isinstance(results_raw, list):
+        raise ValueError("results must be a list")
+    if not results_raw:
+        raise ValueError("results must not be empty")
+
+    results = [parse_sentiment_result(item) for item in results_raw]
+    ids = [r.message_id for r in results]
+    if len(ids) != len(set(ids)):
+        raise ValueError("duplicate message_ids in results")
+
+    if expected_ids is not None:
+        got_ids = set(ids)
+        unexpected = got_ids - expected_ids
+        if unexpected:
+            raise ValueError(f"unexpected message_ids: {sorted(unexpected)[:5]}")
+        missing = expected_ids - got_ids
+        if missing:
+            raise ValueError(f"Model omitted message_ids: {sorted(missing)[:5]}")
+
+    return results
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Restores batch processing for the nightly sentiment job so catch-up can score multiple messages per Grok request, while keeping the resilience from the single-message path.

- Configurable `SENTIMENT_BATCH_SIZE` (default `10`)
- Batch prompt + `{"results": [...]}` parsing with coverage checks
- On malformed/incomplete batch responses: retry, then fall back to per-message scoring
- Individual fallback failures are logged and skipped (one bad item cannot abort the run)
- Unscored-message fetch uses SQL `LIMIT` when a nightly/manual limit is set

## Test plan
- [x] `pytest tests/test_sentiment_job.py tests/test_bot_loading.py`
- [ ] CI green on this PR
- [ ] Optional: run `/score_sentiment limit:20` in Discord and confirm batch progress logs + upserts

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8a2d-5b00-743f-8cf3-d6d5044a4f3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8a2d-5b00-743f-8cf3-d6d5044a4f3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

