### PR TITLE
Remove Dinkscord promo text from first win message

### DIFF
--- a/cogs/first.py
+++ b/cogs/first.py
@@ -56,7 +56,6 @@ class First(commands.Cog):
                 Author = ctx.author.mention
                 msg = f"{Author} is first today! 🥳 +{DINK_MINT_AMOUNT:g} **DINK**"
                 if PROMOTE_DINKSCORD_ON_FIRST:
-                    msg += "\nCheck out the new Dinkscord website"
                     await ctx.send(msg, view=dinkscord_link_view())
                 else:
                     await ctx.send(msg)

--- a/tests/test_first_commands.py
+++ b/tests/test_first_commands.py
@@ -12,10 +12,7 @@ from utils.constants import GENERAL_CHANNEL_ID
 
 
 def _expected_first_win(mention: str) -> str:
-    return (
-        f"{mention} is first today! 🥳 +1 **DINK**\n"
-        "Check out the new Dinkscord website"
-    )
+    return f"{mention} is first today! 🥳 +1 **DINK**"
 
 
 def _est_today_df(date_str: str, user_id: str = "999") -> pd.DataFrame:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removes the “Check out the new Dinkscord website” line from the successful `/1st` win message.
- Keeps the Visit dinkscord.com button attached to that message.
- Updates unit tests to match the shortened win message.

## Test plan
- [x] `pytest tests/test_first_commands.py -v`
- [ ] CI Tests workflow on this PR passes
- [ ] Merge to `main` after unit tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fac19-59a7-780f-ae4a-3daf0cce731d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fac19-59a7-780f-ae4a-3daf0cce731d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

