### PR TITLE
Document GitHub secret cleanup after Postgres cutover

### DIFF
--- a/docs/GITHUB_SECRETS_POSTGRES.md
+++ b/docs/GITHUB_SECRETS_POSTGRES.md
@@ -1,0 +1,15 @@
+# GitHub Actions secrets after VPS + Postgres cutover
+
+CI uses a workflow `services:` Postgres container. Deploy uses SSH like Dinkboard.
+
+## Delete (obsolete)
+
+- `SQL_HOST`, `SQL_USER`, `SQL_PASSWORD`, `SQL_DATABASE` (remote MySQL)
+- `PEBBLEHOST_SERVER_ID`, `PEBBLEHOST_API_TOKEN`
+
+## Add / keep
+
+- `VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY` (same values as the Dinkboard repo)
+- `XAI_API_KEY` (tests / optional)
+
+Production bot credentials live only on the VPS in `/opt/apps/discordbot/.env` (`DISCORD_TOKEN`, `XAI_API_KEY`, `SQL_*` → Postgres).


### PR DESCRIPTION
## Summary
- Document which Actions secrets to delete (MySQL / PebbleHost) and which to add (VPS SSH) after the Postgres VPS migration.

## Test plan
- [ ] Docs-only