### PR TITLE
Fix Grok empty replies after server-side tools and sentiment sarcasm upsert

### DIFF
--- a/chatgpt_functions.py
+++ b/chatgpt_functions.py
@@ -17,7 +17,7 @@ import os
 from dotenv import load_dotenv
 from xai_sdk import Client
 from xai_sdk.chat import user, system, image, tool, tool_result
-from xai_sdk.tools import web_search, x_search
+from xai_sdk.tools import get_tool_call_type, web_search, x_search
 
 from utils import self_knowledge
 
@@ -31,6 +31,27 @@ GROK_IMAGINE_FILENAME = "grok-imagine.jpg"  # xAI base64 responses are JPEG
 
 # Safety cap on client-side tool round-trips per user message
 MAX_TOOL_ROUNDS = 5
+
+# Server-side tool function names (observability only — xAI already executed these).
+# Used as a fallback when get_tool_call_type() is unavailable (e.g. test mocks).
+_SERVER_SIDE_TOOL_NAMES = frozenset(
+    {
+        "web_search",
+        "web_search_with_snippets",
+        "browse_page",
+        "open_page",
+        "open_page_with_find",
+        "search_images",
+        "x_user_search",
+        "x_keyword_search",
+        "x_semantic_search",
+        "x_thread_fetch",
+        "code_execution",
+        "view_x_video",
+        "view_image",
+        "collections_search",
+    }
+)
 
 
 class GrokClient:
@@ -60,6 +81,35 @@ class GrokClient:
     def _build_tools(self) -> list:
         return [web_search(), x_search(), *self._client_tools]
 
+    def _is_client_side_tool_call(self, tool_call) -> bool:
+        """Return True only for tools that must be executed locally.
+
+        Server-side tools (web_search, x_search, …) are already run by xAI and
+        appear on response.tool_calls for observability. Feeding them back as
+        client tool results empties the reply.
+
+        Check known server-side function names first — get_tool_call_type() can
+        mis-classify non-proto mocks (type defaults to CLIENT_SIDE_TOOL).
+        """
+        name = getattr(getattr(tool_call, "function", None), "name", "") or ""
+        if name in _SERVER_SIDE_TOOL_NAMES:
+            return False
+        try:
+            return get_tool_call_type(tool_call) == "client_side_tool"
+        except Exception:
+            return True
+
+    def _client_side_tool_calls(self, response) -> list:
+        calls = getattr(response, "tool_calls", None) or []
+        client_calls = []
+        for tool_call in calls:
+            if self._is_client_side_tool_call(tool_call):
+                client_calls.append(tool_call)
+            else:
+                name = getattr(getattr(tool_call, "function", None), "name", "?")
+                logger.info("Grok server-side tool used: %s", name)
+        return client_calls
+
     def _execute_tool_call(self, tool_call) -> str:
         """Run one client-side tool call and return its string result."""
         name = tool_call.function.name
@@ -80,12 +130,19 @@ class GrokClient:
             return f"Error: tool '{name}' failed to execute."
 
     def _sample_with_tools(self, chat):
-        """Sample a response, executing client-side tool calls until Grok answers."""
+        """Sample a response, executing client-side tool calls until Grok answers.
+
+        Server-side tool calls on the response are ignored — xAI already executed
+        them. Only client_side_tool entries pause the loop for local handlers.
+        """
         response = chat.sample()
         rounds = 0
-        while getattr(response, "tool_calls", None) and rounds < MAX_TOOL_ROUNDS:
+        while rounds < MAX_TOOL_ROUNDS:
+            client_calls = self._client_side_tool_calls(response)
+            if not client_calls:
+                break
             chat.append(response)
-            for tool_call in response.tool_calls:
+            for tool_call in client_calls:
                 output = self._execute_tool_call(tool_call)
                 chat.append(tool_result(output, tool_call_id=tool_call.id))
             response = chat.sample()

--- a/tests/test_self_knowledge.py
+++ b/tests/test_self_knowledge.py
@@ -238,3 +238,80 @@ def test_grok_client_caps_tool_rounds(report, mock_db_ops):
         MAX_TOOL_ROUNDS + 1,
         chat.sample.call_count,
     )
+
+
+def test_grok_client_skips_server_side_tool_calls(report, mock_db_ops):
+    """web_search/x_search are observability only — do not feed fake client results."""
+    from chatgpt_functions import GrokClient
+
+    with patch("chatgpt_functions.Client") as mock_client_cls:
+        grok = GrokClient(api_key="test-key", bot=None)
+        chat = MagicMock()
+        mock_client_cls.return_value.chat.create.return_value = chat
+
+        search_response = MagicMock()
+        search_response.tool_calls = [
+            _make_tool_call("web_search", {"query": "SEC NIL"}),
+            _make_tool_call("web_search", {"query": "college football"}),
+            _make_tool_call("browse_page", {"url": "https://example.com"}),
+        ]
+        search_response.id = "resp-search"
+        search_response.content = (
+            "NIL leveled the field, so SEC dominance looks less automatic."
+        )
+        chat.sample.return_value = search_response
+
+        next_id, text = grok.send_message(
+            "why is the SEC narrative shifting?",
+            system_prompt="sys",
+        )
+
+    # One sample only — server-side tool_calls must not trigger a client tool loop.
+    assert chat.sample.call_count == 1
+    assert next_id == "resp-search"
+    assert "NIL" in text
+    assert_eq(
+        report,
+        SECTION_SELF_KNOWLEDGE,
+        "server-side tools skipped",
+        "kept content",
+        "kept content",
+    )
+
+
+def test_grok_client_runs_client_tools_after_server_side(report, mock_db_ops):
+    from chatgpt_functions import GrokClient
+
+    with patch("chatgpt_functions.Client") as mock_client_cls:
+        grok = GrokClient(api_key="test-key", bot=None)
+        chat = MagicMock()
+        mock_client_cls.return_value.chat.create.return_value = chat
+
+        mixed_response = MagicMock()
+        mixed_response.tool_calls = [
+            _make_tool_call("web_search", {"query": "dink"}),
+            _make_tool_call("get_bot_documentation", {"topic": "dinkcoin"}),
+        ]
+        mixed_response.id = "resp-mixed"
+        mixed_response.content = ""
+
+        final_response = MagicMock()
+        final_response.tool_calls = []
+        final_response.id = "resp-final"
+        final_response.content = "DINK is minted by winning _1st."
+        chat.sample.side_effect = [mixed_response, final_response]
+
+        next_id, text = grok.send_message("how does dinkcoin work?", system_prompt="sys")
+
+    assert chat.sample.call_count == 2
+    assert text == "DINK is minted by winning _1st."
+    assert next_id == "resp-final"
+    # system + user + assistant(mixed) + one client tool_result (not web_search).
+    assert chat.append.call_count == 4
+    assert_eq(
+        report,
+        SECTION_SELF_KNOWLEDGE,
+        "mixed tools",
+        "client executed",
+        "client executed",
+    )

--- a/tests/test_sentiment_job.py
+++ b/tests/test_sentiment_job.py
@@ -138,6 +138,9 @@ def test_upsert_results_writes_rows():
     assert rows[0][0] == 123
     assert rows[0][1] == "positive"
     assert rows[0][3] == "joy"
+    # Postgres BOOLEAN rejects smallint — must bind a real bool.
+    assert rows[0][4] is False
+    assert isinstance(rows[0][4], bool)
     assert rows[0][9] == "grok-4.3"
 
 

--- a/utils/sentiment_job.py
+++ b/utils/sentiment_job.py
@@ -400,7 +400,7 @@ def upsert_results(results: list[SentimentResult], *, model: str) -> int:
                 r.polarity,
                 float(r.polarity_score),
                 ",".join(r.emotions),
-                int(bool(r.sarcasm)),
+                bool(r.sarcasm),
                 r.toxicity,
                 r.directed_at,
                 float(r.confidence),


### PR DESCRIPTION
## Summary
- Stop treating xAI server-side tool calls (`web_search`, `browse_page`, X search, etc.) as client-side tools, which was wiping `/ask` replies after successful agentic search.
- Bind `message_sentiment.sarcasm` as a Postgres `boolean` instead of `0`/`1` so the nightly sentiment upsert no longer fails with `DatatypeMismatch`.

## Test plan
- [x] `pytest tests/test_self_knowledge.py tests/test_sentiment_job.py`
- [ ] CI green on this PR
- [ ] After deploy: `/ask` a current-events question that needs web search and confirm a real reply (not the empty-reply fallback)
- [ ] Confirm next nightly sentiment run writes rows without sarcasm type errors