### PR TITLE
Fix nightly sentiment writing zero rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,12 @@ celerybeat.pid
 # SageMath parsed files
 *.sage.py
 
+# Local Cursor agent notes / rules (not shared in the repo)
+.cursor/
+
+# macOS
+.DS_Store
+
 # Environments
 .env
 .venv

--- a/tests/test_sentiment_job.py
+++ b/tests/test_sentiment_job.py
@@ -134,11 +134,12 @@ def test_upsert_results_writes_rows():
         written = sentiment_job.upsert_results([result], model="grok-4.3")
     assert written == 1
     execmany.assert_called_once()
+    # psycopg3 may adapt Python bool as smallint; cast in SQL so Postgres accepts it.
+    assert "%s::boolean" in execmany.call_args.args[0]
     rows = execmany.call_args.args[1]
     assert rows[0][0] == 123
     assert rows[0][1] == "positive"
     assert rows[0][3] == "joy"
-    # Postgres BOOLEAN rejects smallint — must bind a real bool.
     assert rows[0][4] is False
     assert isinstance(rows[0][4], bool)
     assert rows[0][9] == "grok-4.3"
@@ -431,6 +432,40 @@ def test_coerce_emotion_used_as_polarity():
     assert result.polarity == "neutral"
     assert result.emotions[0] == "surprise"
     assert "joy" in result.emotions
+
+
+def test_emotion_aliases_map_confusion():
+    result = parse_sentiment_result(
+        {
+            "message_id": "8",
+            "polarity": "neutral",
+            "polarity_score": 0.0,
+            "emotions": ["confusion"],
+            "sarcasm": False,
+            "toxicity": "none",
+            "directed_at": "general",
+            "confidence": 0.7,
+            "rationale": "Unclear intent",
+        }
+    )
+    assert result.emotions == ["surprise"]
+
+
+def test_unknown_emotions_fall_back_to_neutral():
+    result = parse_sentiment_result(
+        {
+            "message_id": "9",
+            "polarity": "neutral",
+            "polarity_score": 0.0,
+            "emotions": ["existential-dread"],
+            "sarcasm": False,
+            "toxicity": "none",
+            "directed_at": "general",
+            "confidence": 0.5,
+            "rationale": "Weird label",
+        }
+    )
+    assert result.emotions == ["neutral"]
 
 
 def test_invalid_polarity_still_raises():

--- a/utils/sentiment_job.py
+++ b/utils/sentiment_job.py
@@ -97,7 +97,7 @@ INSERT INTO message_sentiment (
   message_id, polarity, polarity_score, emotions, sarcasm, toxicity,
   directed_at, confidence, rationale, model
 ) VALUES (
-  %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+  %s, %s, %s, %s, %s::boolean, %s, %s, %s, %s, %s
 )
 ON CONFLICT (message_id) DO UPDATE SET
   polarity = EXCLUDED.polarity,

--- a/utils/sentiment_schema.py
+++ b/utils/sentiment_schema.py
@@ -24,6 +24,23 @@ ALLOWED_EMOTIONS = frozenset(
     }
 )
 
+# Models occasionally invent near-synonyms; map them so one label cannot abort a batch.
+EMOTION_ALIASES = {
+    "confusion": "surprise",
+    "confused": "surprise",
+    "curiosity": "surprise",
+    "curious": "surprise",
+    "happiness": "joy",
+    "happy": "joy",
+    "sad": "sadness",
+    "afraid": "fear",
+    "scared": "fear",
+    "frustrated": "annoyance",
+    "frustration": "annoyance",
+    "irritation": "annoyance",
+    "irritated": "annoyance",
+}
+
 
 @dataclass(frozen=True)
 class SentimentResult:
@@ -66,6 +83,16 @@ def _coerce_polarity(raw_polarity: Any, polarity_score: float) -> tuple[str, str
     raise ValueError(f"invalid polarity: {polarity!r}")
 
 
+def _normalize_emotion(emotion: Any) -> str | None:
+    key = str(emotion).strip().lower()
+    if not key:
+        return None
+    key = EMOTION_ALIASES.get(key, key)
+    if key in ALLOWED_EMOTIONS:
+        return key
+    return None
+
+
 def _clean_emotions(values: Any, *, extra: str | None = None) -> list[str]:
     if values is None:
         values = []
@@ -73,13 +100,14 @@ def _clean_emotions(values: Any, *, extra: str | None = None) -> list[str]:
         raise ValueError("emotions must be a list")
     cleaned: list[str] = []
     for emotion in values:
-        key = str(emotion).strip().lower()
-        if key not in ALLOWED_EMOTIONS:
-            raise ValueError(f"emotion '{emotion}' not in {sorted(ALLOWED_EMOTIONS)}")
+        key = _normalize_emotion(emotion)
+        if key is None:
+            continue
         if key not in cleaned:
             cleaned.append(key)
-    if extra and extra in ALLOWED_EMOTIONS and extra not in cleaned:
-        cleaned.insert(0, extra)
+    extra_key = _normalize_emotion(extra) if extra else None
+    if extra_key and extra_key not in cleaned:
+        cleaned.insert(0, extra_key)
     if not cleaned:
         cleaned = ["neutral"]
     return cleaned[:3]


### PR DESCRIPTION
## Summary
- Cast `sarcasm` as `%s::boolean` on upsert so psycopg3 `executemany` no longer fails with `boolean vs smallint` (root cause of 0 rows written each night)
- Map/coerce unknown emotion labels (e.g. `confusion`) instead of aborting whole batches on schema validation

## Test plan
- [x] `pytest tests/test_sentiment_job.py` (26 passed)
- [ ] After merge/deploy: confirm nightly job or `/score_sentiment` writes rows (`Upserted N sentiment rows` with N > 0)
- [ ] Spot-check VPS logs for absence of `DatatypeMismatch` / `emotion 'confusion'` hard failures