### PR TITLE
Add YouTube voice streaming (/play URL or search)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc libpq-dev \
+    gcc libpq-dev ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ Successful `/1st` claims award **1 DINK** (configurable via `DINK_MINT_AMOUNT`).
 | `/pay` | Send DINK to another user |
 | `/request` | Ask another user for DINK (Accept / Decline) |
 
+### Music (YouTube voice)
+
+Join a voice channel, then:
+
+| Command | Description |
+|---------|-------------|
+| `/play <url or search>` | Play a YouTube URL or the top search result |
+| `/skip` | Skip the current track |
+| `/stop` | Stop and clear the queue |
+| `/queue` | Show the queue |
+| `/np` | Now playing |
+| `/pause` / `/resume` | Pause or resume |
+| `/leave` | Disconnect from voice |
+
+Requires FFmpeg + yt-dlp in the container (installed via the Dockerfile / `requirements.txt`). The bot needs **Connect** and **Speak** permissions in the voice channel.
+
 Setup: DinkCoin tables are created with the shared Postgres schema (`deploy/postgres/init.sql` on the dinkboard VPS); `scripts/dinkcoin_schema.sql` is the same DDL for local use.
 
 ## Project Structure
@@ -95,6 +111,7 @@ Setup: DinkCoin tables are created with the shared Postgres schema (`deploy/post
   - `ai.py`: AI-related commands including ChatGPT integration and DALL·E 3 image generation.
   - `first.py`: Commands for tracking and managing first messages of the day.
   - `dinkcoin.py`: DinkCoin balance, ledger, and peer-to-peer transfers.
+  - `music.py`: YouTube voice playback (`/play` URL or search) via yt-dlp + FFmpeg.
   - `misc.py`: Miscellaneous utility commands.
   - `server.py`: Server management and dashboard-related commands.
   - `utility.py`: General utility commands.

--- a/bot.py
+++ b/bot.py
@@ -40,6 +40,7 @@ class DinkBot(commands.Bot):
         await self.load_extension('cogs.utility')
         await self.load_extension('cogs.misc')
         await self.load_extension('cogs.sentiment')
+        await self.load_extension('cogs.music')
 
         await self._sync_app_commands()
         self.loop.create_task(self._console_post_loop())

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -1,0 +1,396 @@
+"""YouTube voice playback via yt-dlp + FFmpeg (URL or search query)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass
+from typing import Deque, Dict, Optional
+from collections import deque
+from urllib.parse import urlparse
+
+import discord
+import yt_dlp
+from discord import app_commands
+from discord.ext import commands
+
+from utils.interactions import acknowledge
+
+logger = logging.getLogger(__name__)
+
+MAX_QUEUE_SIZE = 50
+
+YOUTUBE_HOSTS = frozenset({
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "music.youtube.com",
+    "youtu.be",
+    "www.youtu.be",
+})
+
+YDL_OPTIONS = {
+    "format": "bestaudio/best",
+    "noplaylist": True,
+    "quiet": True,
+    "no_warnings": True,
+    "default_search": "ytsearch",
+    "source_address": "0.0.0.0",
+}
+
+FFMPEG_OPTIONS = {
+    "before_options": "-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5",
+    "options": "-vn",
+}
+
+_YOUTUBE_URL_RE = re.compile(
+    r"(https?://)?(www\.)?(youtube\.com|youtu\.be)/",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class Track:
+    title: str
+    webpage_url: str
+    duration: Optional[int]
+    requester_id: int
+    requester_name: str
+
+
+def is_youtube_url(query: str) -> bool:
+    """Return True if query looks like a YouTube watch/share URL."""
+    text = query.strip()
+    if not _YOUTUBE_URL_RE.search(text):
+        return False
+    # Reject bare hostnames without a path/query that aren't youtu.be short links
+    try:
+        parsed = urlparse(text if "://" in text else f"https://{text}")
+    except ValueError:
+        return False
+    host = (parsed.hostname or "").lower()
+    return host in YOUTUBE_HOSTS
+
+
+def to_ydl_query(query: str) -> str:
+    """Map user input to a yt-dlp URL or ytsearch1 query."""
+    text = query.strip()
+    if is_youtube_url(text):
+        if "://" not in text:
+            return f"https://{text}"
+        return text
+    return f"ytsearch1:{text}"
+
+
+def format_duration(seconds: Optional[int]) -> str:
+    if seconds is None:
+        return "?:??"
+    seconds = max(0, int(seconds))
+    minutes, sec = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{sec:02d}"
+    return f"{minutes}:{sec:02d}"
+
+
+def _pick_entry(info: dict) -> dict:
+    if "entries" in info:
+        for entry in info["entries"]:
+            if entry:
+                return entry
+        raise ValueError("No search results found.")
+    return info
+
+
+def extract_track_info(query: str) -> dict:
+    """Resolve a URL or search query to track metadata (no download)."""
+    ydl_query = to_ydl_query(query)
+    with yt_dlp.YoutubeDL(YDL_OPTIONS) as ydl:
+        info = ydl.extract_info(ydl_query, download=False)
+    entry = _pick_entry(info)
+    webpage_url = entry.get("webpage_url") or entry.get("url")
+    title = entry.get("title") or "Unknown title"
+    duration = entry.get("duration")
+    if not webpage_url:
+        raise ValueError("Could not resolve a playable YouTube URL.")
+    return {
+        "title": title,
+        "webpage_url": webpage_url,
+        "duration": duration,
+    }
+
+
+def extract_stream_url(webpage_url: str) -> str:
+    """Fetch a fresh audio stream URL for an already-resolved video page."""
+    with yt_dlp.YoutubeDL(YDL_OPTIONS) as ydl:
+        info = ydl.extract_info(webpage_url, download=False)
+    entry = _pick_entry(info)
+    stream_url = entry.get("url")
+    if not stream_url:
+        raise ValueError("Could not get an audio stream for that video.")
+    return stream_url
+
+
+class GuildPlayer:
+    """In-memory queue + playback state for one guild."""
+
+    def __init__(self, cog: "Music", guild_id: int):
+        self.cog = cog
+        self.guild_id = guild_id
+        self.queue: Deque[Track] = deque()
+        self.current: Optional[Track] = None
+        self._lock = asyncio.Lock()
+
+    def is_idle(self) -> bool:
+        return self.current is None and not self.queue
+
+
+class Music(commands.Cog):
+    """Play YouTube audio in a voice channel (URL or search)."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self._players: Dict[int, GuildPlayer] = {}
+
+    def _player(self, guild_id: int) -> GuildPlayer:
+        if guild_id not in self._players:
+            self._players[guild_id] = GuildPlayer(self, guild_id)
+        return self._players[guild_id]
+
+    async def _ensure_voice(self, ctx: commands.Context) -> discord.VoiceClient:
+        if ctx.guild is None:
+            raise commands.CommandError("This command only works in a server.")
+
+        author_voice = getattr(ctx.author, "voice", None)
+        channel = author_voice.channel if author_voice else None
+        if channel is None:
+            raise commands.CommandError("Join a voice channel first, then use `/play`.")
+
+        voice = ctx.voice_client
+        if voice is None:
+            return await channel.connect()
+        if voice.channel != channel:
+            await voice.move_to(channel)
+        return voice
+
+    async def _play_next(self, guild_id: int) -> None:
+        player = self._player(guild_id)
+        guild = self.bot.get_guild(guild_id)
+        if guild is None:
+            player.current = None
+            player.queue.clear()
+            return
+
+        voice = guild.voice_client
+        async with player._lock:
+            if voice is None or not voice.is_connected():
+                player.current = None
+                player.queue.clear()
+                return
+
+            if not player.queue:
+                player.current = None
+                return
+
+            track = player.queue.popleft()
+            player.current = track
+
+            try:
+                stream_url = await asyncio.to_thread(extract_stream_url, track.webpage_url)
+                source = discord.FFmpegOpusAudio(stream_url, **FFMPEG_OPTIONS)
+            except Exception:
+                logger.exception("Failed to start track %s", track.webpage_url)
+                player.current = None
+                # Skip broken track and continue
+                self.bot.loop.create_task(self._play_next(guild_id))
+                return
+
+            def _after(error: Optional[Exception]) -> None:
+                if error:
+                    logger.error("Playback error in guild %s: %s", guild_id, error)
+                asyncio.run_coroutine_threadsafe(self._play_next(guild_id), self.bot.loop)
+
+            voice.play(source, after=_after)
+
+    @commands.hybrid_command(brief="Play a YouTube URL or search query in voice")
+    @app_commands.describe(query="YouTube URL or search text (e.g. tubthumping)")
+    async def play(self, ctx: commands.Context, *, query: str):
+        """Play audio from a YouTube URL or the top search result."""
+        if ctx.guild is None:
+            await ctx.send("This command only works in a server.")
+            return
+
+        query = query.strip()
+        if not query:
+            await ctx.send("Give me a YouTube URL or something to search for.")
+            return
+
+        player = self._player(ctx.guild.id)
+
+        async with acknowledge(ctx):
+            try:
+                await self._ensure_voice(ctx)
+            except commands.CommandError as exc:
+                await ctx.send(str(exc))
+                return
+
+            try:
+                info = await asyncio.to_thread(extract_track_info, query)
+            except Exception as exc:
+                logger.exception("yt-dlp failed for query %r", query)
+                await ctx.send(f"Couldn't find that on YouTube: {exc}")
+                return
+
+            track = Track(
+                title=info["title"],
+                webpage_url=info["webpage_url"],
+                duration=info.get("duration"),
+                requester_id=ctx.author.id,
+                requester_name=ctx.author.display_name,
+            )
+
+            voice = ctx.voice_client
+            should_start = (
+                voice is not None
+                and not voice.is_playing()
+                and not voice.is_paused()
+                and player.current is None
+            )
+
+            if should_start:
+                player.queue.appendleft(track)
+                await self._play_next(ctx.guild.id)
+                await ctx.send(
+                    f"▶️ **Now playing:** [{track.title}]({track.webpage_url}) "
+                    f"(`{format_duration(track.duration)}`) — requested by {track.requester_name}"
+                )
+            else:
+                if len(player.queue) >= MAX_QUEUE_SIZE:
+                    await ctx.send(f"Queue is full ({MAX_QUEUE_SIZE} tracks).")
+                    return
+                player.queue.append(track)
+                position = len(player.queue)
+                await ctx.send(
+                    f"➕ **Queued #{position}:** [{track.title}]({track.webpage_url}) "
+                    f"(`{format_duration(track.duration)}`) — requested by {track.requester_name}"
+                )
+
+    @commands.hybrid_command(brief="Skip the current track")
+    async def skip(self, ctx: commands.Context):
+        """Skip the track that is playing now."""
+        if ctx.guild is None or ctx.voice_client is None:
+            await ctx.send("I'm not playing anything.")
+            return
+        if not ctx.voice_client.is_playing() and not ctx.voice_client.is_paused():
+            await ctx.send("I'm not playing anything.")
+            return
+        ctx.voice_client.stop()
+        await ctx.send("⏭️ Skipped.")
+
+    @commands.hybrid_command(brief="Stop playback and clear the queue")
+    async def stop(self, ctx: commands.Context):
+        """Stop playback and clear the queue (stays in the voice channel)."""
+        if ctx.guild is None:
+            await ctx.send("This command only works in a server.")
+            return
+        player = self._player(ctx.guild.id)
+        player.queue.clear()
+        player.current = None
+        if ctx.voice_client and (ctx.voice_client.is_playing() or ctx.voice_client.is_paused()):
+            ctx.voice_client.stop()
+        await ctx.send("⏹️ Stopped and cleared the queue.")
+
+    @commands.hybrid_command(brief="Show the upcoming queue")
+    async def queue(self, ctx: commands.Context):
+        """Show the current track and upcoming queue."""
+        if ctx.guild is None:
+            await ctx.send("This command only works in a server.")
+            return
+        player = self._player(ctx.guild.id)
+        if player.current is None and not player.queue:
+            await ctx.send("Queue is empty.")
+            return
+
+        lines = []
+        if player.current is not None:
+            lines.append(
+                f"**Now playing:** [{player.current.title}]({player.current.webpage_url}) "
+                f"(`{format_duration(player.current.duration)}`)"
+            )
+        if player.queue:
+            lines.append("**Up next:**")
+            for i, track in enumerate(list(player.queue)[:15], start=1):
+                lines.append(
+                    f"`{i}.` [{track.title}]({track.webpage_url}) "
+                    f"(`{format_duration(track.duration)}`) — {track.requester_name}"
+                )
+            remaining = len(player.queue) - 15
+            if remaining > 0:
+                lines.append(f"_…and {remaining} more_")
+        await ctx.send("\n".join(lines))
+
+    @commands.hybrid_command(name="np", brief="Show the track playing now")
+    async def now_playing(self, ctx: commands.Context):
+        """Show the track that is playing now."""
+        if ctx.guild is None:
+            await ctx.send("This command only works in a server.")
+            return
+        player = self._player(ctx.guild.id)
+        track = player.current
+        if track is None:
+            await ctx.send("Nothing is playing right now.")
+            return
+        await ctx.send(
+            f"🎵 **Now playing:** [{track.title}]({track.webpage_url}) "
+            f"(`{format_duration(track.duration)}`) — requested by {track.requester_name}"
+        )
+
+    @commands.hybrid_command(brief="Pause the current track")
+    async def pause(self, ctx: commands.Context):
+        """Pause playback."""
+        if ctx.voice_client is None or not ctx.voice_client.is_playing():
+            await ctx.send("Nothing is playing.")
+            return
+        ctx.voice_client.pause()
+        await ctx.send("⏸️ Paused.")
+
+    @commands.hybrid_command(brief="Resume paused playback")
+    async def resume(self, ctx: commands.Context):
+        """Resume paused playback."""
+        if ctx.voice_client is None or not ctx.voice_client.is_paused():
+            await ctx.send("Nothing is paused.")
+            return
+        ctx.voice_client.resume()
+        await ctx.send("▶️ Resumed.")
+
+    @commands.hybrid_command(brief="Leave the voice channel")
+    async def leave(self, ctx: commands.Context):
+        """Disconnect from voice and clear the queue."""
+        if ctx.guild is None:
+            await ctx.send("This command only works in a server.")
+            return
+        player = self._player(ctx.guild.id)
+        player.queue.clear()
+        player.current = None
+        if ctx.voice_client is not None:
+            await ctx.voice_client.disconnect()
+            await ctx.send("👋 Left the voice channel.")
+        else:
+            await ctx.send("I'm not in a voice channel.")
+
+    @commands.Cog.listener()
+    async def on_voice_state_update(self, member, before, after):
+        """Clear state if the bot is disconnected from voice."""
+        if member.id != self.bot.user.id:
+            return
+        if before.channel is not None and after.channel is None:
+            guild_id = before.channel.guild.id
+            player = self._players.get(guild_id)
+            if player is not None:
+                player.queue.clear()
+                player.current = None
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(Music(bot))

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from collections import deque
 from dataclasses import dataclass
 from typing import Deque, Dict, Optional
-from collections import deque
 from urllib.parse import urlparse
 
 import discord
@@ -20,6 +20,7 @@ from utils.interactions import acknowledge
 logger = logging.getLogger(__name__)
 
 MAX_QUEUE_SIZE = 50
+YDL_SOCKET_TIMEOUT = 20
 
 YOUTUBE_HOSTS = frozenset({
     "youtube.com",
@@ -37,20 +38,24 @@ YDL_OPTIONS = {
     "no_warnings": True,
     "default_search": "ytsearch",
     "source_address": "0.0.0.0",
+    "socket_timeout": YDL_SOCKET_TIMEOUT,
+    "cachedir": False,
 }
 
 FFMPEG_OPTIONS = {
-    "before_options": "-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5",
+    "before_options": (
+        "-nostdin -reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5"
+    ),
     "options": "-vn",
 }
 
-_YOUTUBE_URL_RE = re.compile(
-    r"(https?://)?(www\.)?(youtube\.com|youtu\.be)/",
+_YOUTUBE_HOST_RE = re.compile(
+    r"^(?:https?://)?(?:www\.)?(?:music\.)?(?:m\.)?(?:youtube\.com|youtu\.be)/",
     re.IGNORECASE,
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class Track:
     title: str
     webpage_url: str
@@ -60,17 +65,26 @@ class Track:
 
 
 def is_youtube_url(query: str) -> bool:
-    """Return True if query looks like a YouTube watch/share URL."""
+    """True only when the entire query is a YouTube URL (not search text)."""
     text = query.strip()
-    if not _YOUTUBE_URL_RE.search(text):
+    if not text or any(ch.isspace() for ch in text):
         return False
-    # Reject bare hostnames without a path/query that aren't youtu.be short links
+    if not _YOUTUBE_HOST_RE.match(text):
+        return False
     try:
         parsed = urlparse(text if "://" in text else f"https://{text}")
     except ValueError:
         return False
     host = (parsed.hostname or "").lower()
-    return host in YOUTUBE_HOSTS
+    if host not in YOUTUBE_HOSTS:
+        return False
+    # Require a video path or query so bare "youtube.com/" is not treated as a URL play.
+    if host.endswith("youtu.be"):
+        return bool(parsed.path.strip("/"))
+    path = parsed.path or ""
+    return bool(parsed.query) or path.startswith(
+        ("/watch", "/shorts/", "/live/", "/embed/", "/v/")
+    )
 
 
 def to_ydl_query(query: str) -> str:
@@ -94,6 +108,11 @@ def format_duration(seconds: Optional[int]) -> str:
     return f"{minutes}:{sec:02d}"
 
 
+def safe_title(title: str) -> str:
+    """Neutralize markdown characters that break Discord message formatting."""
+    return discord.utils.escape_markdown(title).replace("[", "").replace("]", "")
+
+
 def _pick_entry(info: dict) -> dict:
     if "entries" in info:
         for entry in info["entries"]:
@@ -103,28 +122,41 @@ def _pick_entry(info: dict) -> dict:
     return info
 
 
+def _webpage_url_from_entry(entry: dict) -> str:
+    """Prefer a stable watch URL; never fall back to expiring CDN stream URLs."""
+    for key in ("webpage_url", "original_url"):
+        value = entry.get(key)
+        if value and is_youtube_url(value):
+            return value if "://" in value else f"https://{value}"
+    video_id = entry.get("id")
+    if video_id and re.fullmatch(r"[\w-]{6,}", str(video_id)):
+        return f"https://www.youtube.com/watch?v={video_id}"
+    raise ValueError("Could not resolve a playable YouTube URL.")
+
+
 def extract_track_info(query: str) -> dict:
     """Resolve a URL or search query to track metadata (no download)."""
     ydl_query = to_ydl_query(query)
     with yt_dlp.YoutubeDL(YDL_OPTIONS) as ydl:
         info = ydl.extract_info(ydl_query, download=False)
+    if info is None:
+        raise ValueError("No results.")
     entry = _pick_entry(info)
-    webpage_url = entry.get("webpage_url") or entry.get("url")
-    title = entry.get("title") or "Unknown title"
-    duration = entry.get("duration")
-    if not webpage_url:
-        raise ValueError("Could not resolve a playable YouTube URL.")
     return {
-        "title": title,
-        "webpage_url": webpage_url,
-        "duration": duration,
+        "title": entry.get("title") or "Unknown title",
+        "webpage_url": _webpage_url_from_entry(entry),
+        "duration": entry.get("duration"),
     }
 
 
 def extract_stream_url(webpage_url: str) -> str:
     """Fetch a fresh audio stream URL for an already-resolved video page."""
+    if not is_youtube_url(webpage_url):
+        raise ValueError("Refusing to stream a non-YouTube URL.")
     with yt_dlp.YoutubeDL(YDL_OPTIONS) as ydl:
         info = ydl.extract_info(webpage_url, download=False)
+    if info is None:
+        raise ValueError("Could not get an audio stream for that video.")
     entry = _pick_entry(info)
     stream_url = entry.get("url")
     if not stream_url:
@@ -135,15 +167,13 @@ def extract_stream_url(webpage_url: str) -> str:
 class GuildPlayer:
     """In-memory queue + playback state for one guild."""
 
-    def __init__(self, cog: "Music", guild_id: int):
-        self.cog = cog
+    def __init__(self, guild_id: int):
         self.guild_id = guild_id
         self.queue: Deque[Track] = deque()
         self.current: Optional[Track] = None
-        self._lock = asyncio.Lock()
-
-    def is_idle(self) -> bool:
-        return self.current is None and not self.queue
+        self.lock = asyncio.Lock()
+        # Bumped on stop/leave so in-flight yt-dlp extracts do not start audio.
+        self.generation = 0
 
 
 class Music(commands.Cog):
@@ -155,7 +185,7 @@ class Music(commands.Cog):
 
     def _player(self, guild_id: int) -> GuildPlayer:
         if guild_id not in self._players:
-            self._players[guild_id] = GuildPlayer(self, guild_id)
+            self._players[guild_id] = GuildPlayer(guild_id)
         return self._players[guild_id]
 
     async def _ensure_voice(self, ctx: commands.Context) -> discord.VoiceClient:
@@ -167,42 +197,92 @@ class Music(commands.Cog):
         if channel is None:
             raise commands.CommandError("Join a voice channel first, then use `/play`.")
 
+        me = ctx.guild.me
+        if me is not None:
+            perms = channel.permissions_for(me)
+            if not perms.connect or not perms.speak:
+                raise commands.CommandError(
+                    "I need **Connect** and **Speak** permissions in that voice channel."
+                )
+
         voice = ctx.voice_client
-        if voice is None:
-            return await channel.connect()
-        if voice.channel != channel:
-            await voice.move_to(channel)
-        return voice
+        try:
+            if voice is None:
+                return await channel.connect()
+            if voice.channel != channel:
+                await voice.move_to(channel)
+            return voice
+        except asyncio.TimeoutError as exc:
+            raise commands.CommandError("Timed out joining the voice channel.") from exc
+        except discord.ClientException as exc:
+            raise commands.CommandError(f"Could not join voice: {exc}") from exc
+
+    def _track_line(self, track: Track, *, prefix: str = "") -> str:
+        title = safe_title(track.title)
+        return (
+            f"{prefix}**{title}** ({format_duration(track.duration)})\n"
+            f"{track.webpage_url} — {track.requester_name}"
+        )
 
     async def _play_next(self, guild_id: int) -> None:
         player = self._player(guild_id)
         guild = self.bot.get_guild(guild_id)
         if guild is None:
-            player.current = None
-            player.queue.clear()
+            async with player.lock:
+                player.current = None
+                player.queue.clear()
             return
 
-        voice = guild.voice_client
-        async with player._lock:
+        async with player.lock:
+            voice = guild.voice_client
             if voice is None or not voice.is_connected():
                 player.current = None
                 player.queue.clear()
                 return
-
-            if not player.queue:
-                player.current = None
+            # Another starter already owns playback (or pause).
+            if voice.is_playing() or voice.is_paused():
                 return
-
+            player.current = None
+            if not player.queue:
+                return
             track = player.queue.popleft()
             player.current = track
+            generation = player.generation
 
+        try:
+            stream_url = await asyncio.to_thread(extract_stream_url, track.webpage_url)
+        except Exception:
+            logger.exception("Failed to resolve stream for %s", track.webpage_url)
+            async with player.lock:
+                if player.generation != generation:
+                    return
+                if player.current is track:
+                    player.current = None
+            await self._play_next(guild_id)
+            return
+
+        async with player.lock:
+            if player.generation != generation:
+                if player.current is track:
+                    player.current = None
+                return
+            voice = guild.voice_client
+            if voice is None or not voice.is_connected():
+                player.current = None
+                player.queue.clear()
+                return
+            if voice.is_playing() or voice.is_paused():
+                # Lost the race; put the track back at the front.
+                if player.current is track:
+                    player.current = None
+                player.queue.appendleft(track)
+                return
             try:
-                stream_url = await asyncio.to_thread(extract_stream_url, track.webpage_url)
                 source = discord.FFmpegOpusAudio(stream_url, **FFMPEG_OPTIONS)
             except Exception:
-                logger.exception("Failed to start track %s", track.webpage_url)
-                player.current = None
-                # Skip broken track and continue
+                logger.exception("FFmpeg failed for %s", track.webpage_url)
+                if player.current is track:
+                    player.current = None
                 self.bot.loop.create_task(self._play_next(guild_id))
                 return
 
@@ -211,7 +291,13 @@ class Music(commands.Cog):
                     logger.error("Playback error in guild %s: %s", guild_id, error)
                 asyncio.run_coroutine_threadsafe(self._play_next(guild_id), self.bot.loop)
 
-            voice.play(source, after=_after)
+            try:
+                voice.play(source, after=_after)
+            except discord.ClientException:
+                logger.exception("voice.play failed in guild %s", guild_id)
+                if player.current is track:
+                    player.current = None
+                player.queue.appendleft(track)
 
     @commands.hybrid_command(brief="Play a YouTube URL or search query in voice")
     @app_commands.describe(query="YouTube URL or search text (e.g. tubthumping)")
@@ -237,9 +323,11 @@ class Music(commands.Cog):
 
             try:
                 info = await asyncio.to_thread(extract_track_info, query)
-            except Exception as exc:
+            except Exception:
                 logger.exception("yt-dlp failed for query %r", query)
-                await ctx.send(f"Couldn't find that on YouTube: {exc}")
+                await ctx.send(
+                    "Couldn't find that on YouTube. Try a different search or paste a video URL."
+                )
                 return
 
             track = Track(
@@ -250,30 +338,34 @@ class Music(commands.Cog):
                 requester_name=ctx.author.display_name,
             )
 
-            voice = ctx.voice_client
-            should_start = (
-                voice is not None
-                and not voice.is_playing()
-                and not voice.is_paused()
-                and player.current is None
-            )
-
-            if should_start:
-                player.queue.appendleft(track)
-                await self._play_next(ctx.guild.id)
-                await ctx.send(
-                    f"▶️ **Now playing:** [{track.title}]({track.webpage_url}) "
-                    f"(`{format_duration(track.duration)}`) — requested by {track.requester_name}"
+            async with player.lock:
+                voice = ctx.voice_client
+                playing = voice is not None and (
+                    voice.is_playing() or voice.is_paused()
                 )
-            else:
-                if len(player.queue) >= MAX_QUEUE_SIZE:
+                active = player.current is not None or playing
+                if active and len(player.queue) >= MAX_QUEUE_SIZE:
                     await ctx.send(f"Queue is full ({MAX_QUEUE_SIZE} tracks).")
                     return
                 player.queue.append(track)
                 position = len(player.queue)
+                # Start when nothing is playing/extracting. A non-empty idle
+                # queue (e.g. after a dropped after-callback) should recover.
+                should_start = player.current is None and not playing
+
+            if should_start:
+                await self._play_next(ctx.guild.id)
+                # If we recovered an older queued item first, still acknowledge
+                # this request as queued when it was not alone in line.
+                if position == 1:
+                    await ctx.send(self._track_line(track, prefix="▶️ **Now playing:** "))
+                else:
+                    await ctx.send(
+                        self._track_line(track, prefix=f"➕ **Queued #{position}:** ")
+                    )
+            else:
                 await ctx.send(
-                    f"➕ **Queued #{position}:** [{track.title}]({track.webpage_url}) "
-                    f"(`{format_duration(track.duration)}`) — requested by {track.requester_name}"
+                    self._track_line(track, prefix=f"➕ **Queued #{position}:** ")
                 )
 
     @commands.hybrid_command(brief="Skip the current track")
@@ -282,10 +374,11 @@ class Music(commands.Cog):
         if ctx.guild is None or ctx.voice_client is None:
             await ctx.send("I'm not playing anything.")
             return
-        if not ctx.voice_client.is_playing() and not ctx.voice_client.is_paused():
+        voice = ctx.voice_client
+        if not voice.is_playing() and not voice.is_paused():
             await ctx.send("I'm not playing anything.")
             return
-        ctx.voice_client.stop()
+        voice.stop()
         await ctx.send("⏭️ Skipped.")
 
     @commands.hybrid_command(brief="Stop playback and clear the queue")
@@ -295,10 +388,13 @@ class Music(commands.Cog):
             await ctx.send("This command only works in a server.")
             return
         player = self._player(ctx.guild.id)
-        player.queue.clear()
-        player.current = None
-        if ctx.voice_client and (ctx.voice_client.is_playing() or ctx.voice_client.is_paused()):
-            ctx.voice_client.stop()
+        async with player.lock:
+            player.generation += 1
+            player.queue.clear()
+            player.current = None
+        voice = ctx.voice_client
+        if voice and (voice.is_playing() or voice.is_paused()):
+            voice.stop()
         await ctx.send("⏹️ Stopped and cleared the queue.")
 
     @commands.hybrid_command(brief="Show the upcoming queue")
@@ -308,24 +404,28 @@ class Music(commands.Cog):
             await ctx.send("This command only works in a server.")
             return
         player = self._player(ctx.guild.id)
-        if player.current is None and not player.queue:
+        async with player.lock:
+            current = player.current
+            upcoming = list(player.queue)
+
+        if current is None and not upcoming:
             await ctx.send("Queue is empty.")
             return
 
         lines = []
-        if player.current is not None:
+        if current is not None:
             lines.append(
-                f"**Now playing:** [{player.current.title}]({player.current.webpage_url}) "
-                f"(`{format_duration(player.current.duration)}`)"
+                f"**Now playing:** **{safe_title(current.title)}** "
+                f"({format_duration(current.duration)})\n{current.webpage_url}"
             )
-        if player.queue:
+        if upcoming:
             lines.append("**Up next:**")
-            for i, track in enumerate(list(player.queue)[:15], start=1):
+            for i, track in enumerate(upcoming[:15], start=1):
                 lines.append(
-                    f"`{i}.` [{track.title}]({track.webpage_url}) "
-                    f"(`{format_duration(track.duration)}`) — {track.requester_name}"
+                    f"`{i}.` **{safe_title(track.title)}** "
+                    f"({format_duration(track.duration)}) — {track.requester_name}"
                 )
-            remaining = len(player.queue) - 15
+            remaining = len(upcoming) - 15
             if remaining > 0:
                 lines.append(f"_…and {remaining} more_")
         await ctx.send("\n".join(lines))
@@ -337,14 +437,12 @@ class Music(commands.Cog):
             await ctx.send("This command only works in a server.")
             return
         player = self._player(ctx.guild.id)
-        track = player.current
+        async with player.lock:
+            track = player.current
         if track is None:
             await ctx.send("Nothing is playing right now.")
             return
-        await ctx.send(
-            f"🎵 **Now playing:** [{track.title}]({track.webpage_url}) "
-            f"(`{format_duration(track.duration)}`) — requested by {track.requester_name}"
-        )
+        await ctx.send(self._track_line(track, prefix="🎵 **Now playing:** "))
 
     @commands.hybrid_command(brief="Pause the current track")
     async def pause(self, ctx: commands.Context):
@@ -371,25 +469,56 @@ class Music(commands.Cog):
             await ctx.send("This command only works in a server.")
             return
         player = self._player(ctx.guild.id)
-        player.queue.clear()
-        player.current = None
+        async with player.lock:
+            player.generation += 1
+            player.queue.clear()
+            player.current = None
         if ctx.voice_client is not None:
             await ctx.voice_client.disconnect()
             await ctx.send("👋 Left the voice channel.")
         else:
             await ctx.send("I'm not in a voice channel.")
 
+    async def _cleanup_guild_voice(self, guild_id: int) -> None:
+        player = self._players.get(guild_id)
+        if player is None:
+            return
+        async with player.lock:
+            player.generation += 1
+            player.queue.clear()
+            player.current = None
+
     @commands.Cog.listener()
     async def on_voice_state_update(self, member, before, after):
-        """Clear state if the bot is disconnected from voice."""
-        if member.id != self.bot.user.id:
+        """Clear state on bot disconnect; leave when alone in the channel."""
+        bot_user = self.bot.user
+        if bot_user is None:
             return
-        if before.channel is not None and after.channel is None:
-            guild_id = before.channel.guild.id
-            player = self._players.get(guild_id)
-            if player is not None:
-                player.queue.clear()
-                player.current = None
+
+        # Bot was disconnected / moved out of a channel.
+        if member.id == bot_user.id:
+            if before.channel is not None and after.channel is None:
+                await self._cleanup_guild_voice(before.channel.guild.id)
+            return
+
+        # If a human left/moved and the bot is alone, disconnect.
+        channel = before.channel
+        if channel is None:
+            return
+        if after.channel == before.channel:
+            return
+        guild = channel.guild
+        voice = guild.voice_client
+        if voice is None or voice.channel != channel:
+            return
+        humans = [m for m in channel.members if not m.bot]
+        if humans:
+            return
+        await self._cleanup_guild_voice(guild.id)
+        try:
+            await voice.disconnect()
+        except Exception:
+            logger.exception("Failed to auto-disconnect in guild %s", guild.id)
 
 
 async def setup(bot: commands.Bot):

--- a/docs/self_knowledge/music.md
+++ b/docs/self_knowledge/music.md
@@ -1,0 +1,31 @@
+# Music — `/play`
+
+Play YouTube audio in a voice channel. Join a voice channel first, then use
+`/play` with either a **YouTube URL** or a **search phrase**.
+
+## Play — `/play`
+
+- `/play https://youtu.be/...` — play that video's audio
+- `/play tubthumping` — search YouTube and play the top result
+- If something is already playing, new requests are **queued**
+
+Also works with the `_play` prefix.
+
+## Controls
+
+| Command | What it does |
+|---------|----------------|
+| `/skip` | Skip the current track |
+| `/stop` | Stop and clear the queue (bot stays in voice) |
+| `/queue` | Show now playing + upcoming tracks |
+| `/np` | Show the track playing now |
+| `/pause` | Pause |
+| `/resume` | Resume |
+| `/leave` | Disconnect and clear the queue |
+
+## Tips for members
+
+- You must be in a voice channel before `/play`.
+- Search uses YouTube's top match — if it's wrong, paste the exact URL instead.
+- `/voice` is different: that one answers a prompt as an MP3 file in chat, not
+  voice-channel music.

--- a/docs/self_knowledge/overview.md
+++ b/docs/self_knowledge/overview.md
@@ -14,6 +14,9 @@ older `_` prefix still works. Commands are case-insensitive.
 - **Chat & creativity** — `/ask` for questions and conversation (including images
   you attach), `/imagine` for AI art, `/voice` for a spoken reply, and `/clear`
   to start a fresh chat. See the `ai_features` topic.
+- **Music** — `/play` streams YouTube audio in a voice channel from a URL or
+  search text, with `/skip`, `/queue`, `/np`, `/pause`, `/resume`, `/stop`, and
+  `/leave`. See the `music` topic.
 - **Server stats** — you keep track of activity on the server and post a monthly
   report. Stats are also on the public dashboard at https://dinkscord.com
   (`/dashboard` shares a link). See the `server_stats` topic.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ tzdata
 requests
 python-dotenv
 xai-sdk>=1.17.0
+PyNaCl>=1.5.0
+yt-dlp>=2024.8.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ EXPECTED_COMMANDS = frozenset({
     "members", "emojis", "channels",
     "hello", "ping", "simonsays", "dashboard",
     "donation",
+    "play", "skip", "stop", "queue", "np", "pause", "resume", "leave",
 })
 
 

--- a/tests/test_bot_loading.py
+++ b/tests/test_bot_loading.py
@@ -6,13 +6,14 @@ from cogs.ai import AI
 from cogs.dinkcoin import DinkCoin
 from cogs.first import First
 from cogs.misc import Misc
+from cogs.music import Music
 from cogs.sentiment import Sentiment
 from cogs.server import Server
 from cogs.utility import Utility
 from tests.conftest import EXPECTED_COMMANDS
 from tests.reporting import SECTION_WIRING
 
-COG_CLASSES = (First, DinkCoin, Server, AI, Utility, Misc, Sentiment)
+COG_CLASSES = (First, DinkCoin, Server, AI, Utility, Misc, Sentiment, Music)
 
 
 def _server_init_without_tasks(self, bot):
@@ -25,7 +26,7 @@ def _sentiment_init_without_tasks(self, bot):
 
 
 def test_all_cogs_have_expected_names(report):
-    expected = {"First", "DinkCoin", "Server", "AI", "Utility", "Misc", "Sentiment"}
+    expected = {"First", "DinkCoin", "Server", "AI", "Utility", "Misc", "Sentiment", "Music"}
     actual = {cls.__name__ for cls in COG_CLASSES}
     report.record("cog class names", sorted(expected), sorted(actual), section=SECTION_WIRING)
     assert actual == expected
@@ -51,4 +52,4 @@ def test_all_commands_registered(report):
     )
     report.record("command count", len(EXPECTED_COMMANDS), len(registered), section=SECTION_WIRING)
     assert EXPECTED_COMMANDS <= registered
-    assert len(EXPECTED_COMMANDS) == 22
+    assert len(EXPECTED_COMMANDS) == 30

--- a/tests/test_music_commands.py
+++ b/tests/test_music_commands.py
@@ -1,0 +1,136 @@
+"""Unit tests for music helpers and command edge cases."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from cogs.music import (
+    Music,
+    Track,
+    extract_track_info,
+    format_duration,
+    is_youtube_url,
+    to_ydl_query,
+)
+from tests.reporting import SECTION_COMMANDS
+
+
+def test_is_youtube_url_accepts_common_forms(report):
+    cases = [
+        ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", True),
+        ("https://youtu.be/dQw4w9WgXcQ", True),
+        ("youtube.com/watch?v=dQw4w9WgXcQ", True),
+        ("https://music.youtube.com/watch?v=dQw4w9WgXcQ", True),
+        ("tubthumping", False),
+        ("https://example.com/watch?v=dQw4w9WgXcQ", False),
+        ("https://vimeo.com/123", False),
+    ]
+    for value, expected in cases:
+        actual = is_youtube_url(value)
+        report.record(f"is_youtube_url({value!r})", expected, actual, section=SECTION_COMMANDS)
+        assert actual is expected
+
+
+def test_to_ydl_query_url_vs_search(report):
+    url = "https://youtu.be/dQw4w9WgXcQ"
+    assert to_ydl_query(url) == url
+    report.record("to_ydl_query(url)", url, to_ydl_query(url), section=SECTION_COMMANDS)
+
+    search = to_ydl_query("tubthumping")
+    expected = "ytsearch1:tubthumping"
+    report.record("to_ydl_query(search)", expected, search, section=SECTION_COMMANDS)
+    assert search == expected
+
+    bare = to_ydl_query("youtube.com/watch?v=dQw4w9WgXcQ")
+    assert bare.startswith("https://")
+    report.record("to_ydl_query(bare host)", "https://…", bare, section=SECTION_COMMANDS)
+
+
+def test_format_duration(report):
+    assert format_duration(None) == "?:??"
+    assert format_duration(65) == "1:05"
+    assert format_duration(3661) == "1:01:01"
+    report.record("format_duration(65)", "1:05", format_duration(65), section=SECTION_COMMANDS)
+
+
+@patch("cogs.music.yt_dlp.YoutubeDL")
+def test_extract_track_info_search_uses_first_entry(mock_ydl_cls, report):
+    mock_ydl = MagicMock()
+    mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+    mock_ydl.__exit__ = MagicMock(return_value=False)
+    mock_ydl.extract_info.return_value = {
+        "entries": [
+            {
+                "title": "Tubthumping",
+                "webpage_url": "https://www.youtube.com/watch?v=abc",
+                "duration": 271,
+            }
+        ]
+    }
+    mock_ydl_cls.return_value = mock_ydl
+
+    info = extract_track_info("tubthumping")
+    mock_ydl.extract_info.assert_called_once_with("ytsearch1:tubthumping", download=False)
+    assert info["title"] == "Tubthumping"
+    assert info["webpage_url"] == "https://www.youtube.com/watch?v=abc"
+    report.record("extract search title", "Tubthumping", info["title"], section=SECTION_COMMANDS)
+
+
+async def test_play_requires_voice_channel(report, mock_bot, mock_ctx):
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 1
+    mock_ctx.author.voice = None
+    mock_ctx.voice_client = None
+
+    cog = Music(mock_bot)
+    await cog.play.callback(cog, mock_ctx, query="tubthumping")
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("play without VC", "Join a voice channel", actual, section=SECTION_COMMANDS)
+    assert "Join a voice channel" in actual
+
+
+async def test_queue_empty_message(report, mock_bot, mock_ctx):
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 42
+    cog = Music(mock_bot)
+    await cog.queue.callback(cog, mock_ctx)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("empty queue", "Queue is empty.", actual, section=SECTION_COMMANDS)
+    assert actual == "Queue is empty."
+
+
+async def test_np_when_idle(report, mock_bot, mock_ctx):
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 42
+    cog = Music(mock_bot)
+    await cog.now_playing.callback(cog, mock_ctx)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("np idle", "Nothing is playing", actual, section=SECTION_COMMANDS)
+    assert "Nothing is playing" in actual
+
+
+async def test_queue_lists_current_and_upcoming(report, mock_bot, mock_ctx):
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 7
+    cog = Music(mock_bot)
+    player = cog._player(7)
+    player.current = Track(
+        title="Now Song",
+        webpage_url="https://youtu.be/now",
+        duration=120,
+        requester_id=1,
+        requester_name="Alice",
+    )
+    player.queue.append(
+        Track(
+            title="Next Song",
+            webpage_url="https://youtu.be/next",
+            duration=90,
+            requester_id=2,
+            requester_name="Bob",
+        )
+    )
+    await cog.queue.callback(cog, mock_ctx)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("queue contents", "Now Song + Next Song", actual, section=SECTION_COMMANDS)
+    assert "Now Song" in actual
+    assert "Next Song" in actual
+    assert "Bob" in actual

--- a/tests/test_music_commands.py
+++ b/tests/test_music_commands.py
@@ -1,16 +1,28 @@
 """Unit tests for music helpers and command edge cases."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from cogs.music import (
+    MAX_QUEUE_SIZE,
     Music,
     Track,
+    _webpage_url_from_entry,
+    extract_stream_url,
     extract_track_info,
     format_duration,
     is_youtube_url,
+    safe_title,
     to_ydl_query,
 )
 from tests.reporting import SECTION_COMMANDS
+
+
+def _ydl_mock(extract_return):
+    mock_ydl = MagicMock()
+    mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+    mock_ydl.__exit__ = MagicMock(return_value=False)
+    mock_ydl.extract_info.return_value = extract_return
+    return mock_ydl
 
 
 def test_is_youtube_url_accepts_common_forms(report):
@@ -19,14 +31,19 @@ def test_is_youtube_url_accepts_common_forms(report):
         ("https://youtu.be/dQw4w9WgXcQ", True),
         ("youtube.com/watch?v=dQw4w9WgXcQ", True),
         ("https://music.youtube.com/watch?v=dQw4w9WgXcQ", True),
+        ("https://www.youtube.com/shorts/abc123xyz00", True),
         ("tubthumping", False),
+        ("never gonna give you up", False),
         ("https://example.com/watch?v=dQw4w9WgXcQ", False),
         ("https://vimeo.com/123", False),
+        ("https://youtube.com/", False),
+        ("check out https://youtu.be/dQw4w9WgXcQ please", False),
+        ("youtube.com/watch?v=dQw4w9WgXcQ and more", False),
     ]
     for value, expected in cases:
         actual = is_youtube_url(value)
         report.record(f"is_youtube_url({value!r})", expected, actual, section=SECTION_COMMANDS)
-        assert actual is expected
+        assert actual is expected, value
 
 
 def test_to_ydl_query_url_vs_search(report):
@@ -43,40 +60,86 @@ def test_to_ydl_query_url_vs_search(report):
     assert bare.startswith("https://")
     report.record("to_ydl_query(bare host)", "https://…", bare, section=SECTION_COMMANDS)
 
+    # Sentences must not be treated as URLs.
+    assert to_ydl_query("play https://youtu.be/dQw4w9WgXcQ").startswith("ytsearch1:")
+
 
 def test_format_duration(report):
     assert format_duration(None) == "?:??"
+    assert format_duration(0) == "0:00"
     assert format_duration(65) == "1:05"
     assert format_duration(3661) == "1:01:01"
     report.record("format_duration(65)", "1:05", format_duration(65), section=SECTION_COMMANDS)
 
 
+def test_safe_title_strips_link_breakers(report):
+    actual = safe_title("Song [Live] (Official)")
+    report.record("safe_title", "no brackets", actual, section=SECTION_COMMANDS)
+    assert "[" not in actual and "]" not in actual
+
+
+def test_webpage_url_prefers_watch_url_not_cdn(report):
+    entry = {
+        "id": "dQw4w9WgXcQ",
+        "url": "https://googlevideo.com/videoplayback?expire=1",
+        "title": "Rick Roll",
+    }
+    url = _webpage_url_from_entry(entry)
+    report.record("webpage from id", "https://www.youtube.com/watch?v=dQw4w9WgXcQ", url, section=SECTION_COMMANDS)
+    assert url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+
 @patch("cogs.music.yt_dlp.YoutubeDL")
 def test_extract_track_info_search_uses_first_entry(mock_ydl_cls, report):
-    mock_ydl = MagicMock()
-    mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
-    mock_ydl.__exit__ = MagicMock(return_value=False)
-    mock_ydl.extract_info.return_value = {
+    mock_ydl_cls.return_value = _ydl_mock({
         "entries": [
             {
+                "id": "abc123xyz00",
                 "title": "Tubthumping",
-                "webpage_url": "https://www.youtube.com/watch?v=abc",
+                "webpage_url": "https://www.youtube.com/watch?v=abc123xyz00",
                 "duration": 271,
+                "url": "https://googlevideo.com/stream",
             }
         ]
-    }
-    mock_ydl_cls.return_value = mock_ydl
+    })
 
     info = extract_track_info("tubthumping")
-    mock_ydl.extract_info.assert_called_once_with("ytsearch1:tubthumping", download=False)
+    mock_ydl_cls.return_value.extract_info.assert_called_once_with(
+        "ytsearch1:tubthumping", download=False
+    )
     assert info["title"] == "Tubthumping"
-    assert info["webpage_url"] == "https://www.youtube.com/watch?v=abc"
+    assert info["webpage_url"] == "https://www.youtube.com/watch?v=abc123xyz00"
     report.record("extract search title", "Tubthumping", info["title"], section=SECTION_COMMANDS)
+
+
+@patch("cogs.music.yt_dlp.YoutubeDL")
+def test_extract_track_info_empty_search_raises(mock_ydl_cls, report):
+    mock_ydl_cls.return_value = _ydl_mock({"entries": []})
+    try:
+        extract_track_info("zzznonsensequeryzzz")
+        raised = False
+    except ValueError:
+        raised = True
+    report.record("empty search raises", True, raised, section=SECTION_COMMANDS)
+    assert raised
+
+
+@patch("cogs.music.yt_dlp.YoutubeDL")
+def test_extract_stream_url_rejects_non_youtube(mock_ydl_cls, report):
+    try:
+        extract_stream_url("https://example.com/audio.mp3")
+        rejected = False
+    except ValueError:
+        rejected = True
+    report.record("reject non-youtube stream", True, rejected, section=SECTION_COMMANDS)
+    assert rejected
+    mock_ydl_cls.assert_not_called()
 
 
 async def test_play_requires_voice_channel(report, mock_bot, mock_ctx):
     mock_ctx.guild = MagicMock()
     mock_ctx.guild.id = 1
+    mock_ctx.guild.me = None
     mock_ctx.author.voice = None
     mock_ctx.voice_client = None
 
@@ -85,6 +148,125 @@ async def test_play_requires_voice_channel(report, mock_bot, mock_ctx):
     actual = mock_ctx.send.call_args.args[0]
     report.record("play without VC", "Join a voice channel", actual, section=SECTION_COMMANDS)
     assert "Join a voice channel" in actual
+
+
+async def test_play_queues_when_busy(report, mock_bot, mock_ctx):
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 9
+    mock_ctx.guild.me = None
+    voice_state = MagicMock()
+    voice_state.channel = MagicMock()
+    mock_ctx.author.voice = voice_state
+    mock_ctx.voice_client = MagicMock()
+    mock_ctx.voice_client.is_playing.return_value = True
+    mock_ctx.voice_client.is_paused.return_value = False
+    mock_ctx.voice_client.channel = voice_state.channel
+
+    cog = Music(mock_bot)
+    player = cog._player(9)
+    player.current = Track("Current", "https://youtu.be/cur", 10, 1, "A")
+
+    with patch(
+        "cogs.music.extract_track_info",
+        return_value={
+            "title": "Next Up",
+            "webpage_url": "https://www.youtube.com/watch?v=next123456",
+            "duration": 12,
+        },
+    ):
+        await cog.play.callback(cog, mock_ctx, query="next song")
+
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("play while busy", "Queued", actual, section=SECTION_COMMANDS)
+    assert "Queued" in actual
+    assert len(player.queue) == 1
+    assert player.queue[0].title == "Next Up"
+
+
+async def test_play_respects_queue_limit(report, mock_bot, mock_ctx):
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 11
+    mock_ctx.guild.me = None
+    voice_state = MagicMock()
+    voice_state.channel = MagicMock()
+    mock_ctx.author.voice = voice_state
+    mock_ctx.voice_client = MagicMock()
+    mock_ctx.voice_client.is_playing.return_value = True
+    mock_ctx.voice_client.is_paused.return_value = False
+    mock_ctx.voice_client.channel = voice_state.channel
+
+    cog = Music(mock_bot)
+    player = cog._player(11)
+    player.current = Track("Current", "https://youtu.be/cur", 10, 1, "A")
+    for i in range(MAX_QUEUE_SIZE):
+        player.queue.append(Track(f"T{i}", "https://youtu.be/x", 1, 1, "A"))
+
+    with patch(
+        "cogs.music.extract_track_info",
+        return_value={
+            "title": "Overflow",
+            "webpage_url": "https://www.youtube.com/watch?v=overflow01",
+            "duration": 1,
+        },
+    ):
+        await cog.play.callback(cog, mock_ctx, query="overflow")
+
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("queue full", "Queue is full", actual, section=SECTION_COMMANDS)
+    assert "Queue is full" in actual
+    assert len(player.queue) == MAX_QUEUE_SIZE
+
+
+async def test_stop_bumps_generation_and_clears(report, mock_bot, mock_ctx):
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 5
+    mock_ctx.voice_client = MagicMock()
+    mock_ctx.voice_client.is_playing.return_value = True
+    mock_ctx.voice_client.is_paused.return_value = False
+
+    cog = Music(mock_bot)
+    player = cog._player(5)
+    player.current = Track("Now", "https://youtu.be/n", 1, 1, "A")
+    player.queue.append(Track("Next", "https://youtu.be/x", 1, 1, "B"))
+    before = player.generation
+
+    await cog.stop.callback(cog, mock_ctx)
+
+    report.record("stop generation", before + 1, player.generation, section=SECTION_COMMANDS)
+    assert player.generation == before + 1
+    assert player.current is None
+    assert len(player.queue) == 0
+    mock_ctx.voice_client.stop.assert_called_once()
+
+
+async def test_play_next_aborts_stale_generation(report, mock_bot):
+    guild = MagicMock()
+    guild.id = 3
+    voice = MagicMock()
+    voice.is_connected.return_value = True
+    voice.is_playing.return_value = False
+    voice.is_paused.return_value = False
+    guild.voice_client = voice
+    mock_bot.get_guild.return_value = guild
+
+    cog = Music(mock_bot)
+    player = cog._player(3)
+    track = Track("Song", "https://www.youtube.com/watch?v=abc123xyz00", 10, 1, "A")
+    player.queue.append(track)
+
+    def slow_extract(_url):
+        # Simulate /stop during extract: bump generation before play starts.
+        player.generation += 1
+        return "https://cdn.example/stream"
+
+    with patch("cogs.music.extract_stream_url", side_effect=slow_extract):
+        with patch("cogs.music.discord.FFmpegOpusAudio") as ffmpeg:
+            await cog._play_next(3)
+
+    ffmpeg.assert_not_called()
+    voice.play.assert_not_called()
+    assert player.current is None
+    report.record("stale generation aborts play", True, True, section=SECTION_COMMANDS)
 
 
 async def test_queue_empty_message(report, mock_bot, mock_ctx):
@@ -134,3 +316,38 @@ async def test_queue_lists_current_and_upcoming(report, mock_bot, mock_ctx):
     assert "Now Song" in actual
     assert "Next Song" in actual
     assert "Bob" in actual
+
+
+async def test_auto_leave_when_alone(report, mock_bot):
+    cog = Music(mock_bot)
+    mock_bot.user = MagicMock()
+    mock_bot.user.id = 999
+
+    channel = MagicMock()
+    channel.guild.id = 77
+    bot_member = MagicMock()
+    bot_member.bot = True
+    channel.members = [bot_member]
+
+    voice = AsyncMock()
+    voice.channel = channel
+    channel.guild.voice_client = voice
+
+    human = MagicMock()
+    human.id = 1
+    human.bot = False
+    before = MagicMock()
+    before.channel = channel
+    after = MagicMock()
+    after.channel = None
+
+    player = cog._player(77)
+    player.current = Track("X", "https://youtu.be/x", 1, 1, "A")
+    player.queue.append(Track("Y", "https://youtu.be/y", 1, 1, "B"))
+
+    await cog.on_voice_state_update(human, before, after)
+
+    voice.disconnect.assert_awaited()
+    assert player.current is None
+    assert len(player.queue) == 0
+    report.record("auto-leave when alone", True, True, section=SECTION_COMMANDS)

--- a/tests/test_music_commands.py
+++ b/tests/test_music_commands.py
@@ -1,6 +1,6 @@
 """Unit tests for music helpers and command edge cases."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from cogs.music import (
     Music,

--- a/utils/self_knowledge.py
+++ b/utils/self_knowledge.py
@@ -21,6 +21,7 @@ TOPICS = {
     "first_game": "Rules of the daily /1st game: claiming, score, streaks, and juice",
     "dinkcoin": "How DINK works: earning it, spending it, and the leaderboard",
     "ai_features": "How /ask, /imagine, /voice, and /clear work for members",
+    "music": "How /play works: YouTube URLs, search, queue, and voice controls",
     "server_stats": "Activity tracking, the monthly report, and the public dashboard",
 }
 
@@ -43,7 +44,7 @@ def build_command_reference(bot) -> str:
     if bot is None:
         return (
             "Live command registry unavailable. Use get_bot_documentation "
-            "(topics: overview, first_game, dinkcoin, ai_features) for command lists."
+            "(topics: overview, first_game, dinkcoin, ai_features, music) for command lists."
         )
     lines = ["Commands (slash /name; underscore _name also works, case-insensitive):"]
     for cog_name, cog in bot.cogs.items():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds Groovy-style music playback so members can `/play` a YouTube URL **or** a search phrase (e.g. `/play tubthumping`) and hear it in a voice channel.

## What changed
- New `cogs/music.py` with `/play`, `/skip`, `/stop`, `/queue`, `/np`, `/pause`, `/resume`, `/leave`
- yt-dlp resolves URLs or `ytsearch1:` queries; FFmpeg streams audio (no download to disk)
- Dockerfile installs `ffmpeg`; `requirements.txt` adds `yt-dlp` + `PyNaCl`
- Self-knowledge docs + wiring/unit tests updated

## Adversarial review fixes
Follow-up hardening after review of the initial implementation:

- **Race conditions**: concurrent `/play` while idle no longer double-starts; enqueue + start decisions are lock-scoped; `voice.play` guarded against already-playing
- **Stop during extract**: generation token invalidates in-flight yt-dlp work so `/stop`/`/leave` cannot be undone by a late `voice.play`
- **URL resolution**: never treat CDN `entry["url"]` as `webpage_url`; build stable `watch?v=` links from video id
- **URL vs search**: whole-string YouTube URLs only (whitespace → search); reject bare `youtube.com/`
- **Safety/UX**: escape titles for Discord markdown, sanitize user-facing yt-dlp errors, check Connect/Speak perms, auto-leave when alone in VC
- **Tests**: expanded for CDN fallback, empty search, queue limit, stop generation, stale extract abort, auto-leave (134 non-live tests passing)

## Deploy / setup (VPS)
Same flow as today after merge:
```bash
docker compose -f docker-compose.prod.yml up --build -d
```
Ensure the bot role has **Connect** + **Speak** in voice channels. No new env vars for v1.

## Test plan
- [x] Unit tests pass (`134 passed`, non-live)
- [ ] Join VC → `/play tubthumping` plays top result
- [ ] `/play <youtube url>` plays that video
- [ ] Queue, skip, pause/resume, stop, leave work
- [ ] `/stop` during a slow search/extract does not resume unexpectedly

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00b34a3b-3966-4e7d-aab2-3f09aa753995?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00b34a3b-3966-4e7d-aab2-3f09aa753995&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

