### PR TITLE
Support YouTube cookies for /play on the VPS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,8 @@ DINK_MINT_AMOUNT=1
 # SENTIMENT_NIGHTLY_LIMIT=500
 # Messages per Grok request (falls back to per-message scoring if a batch response is bad)
 # SENTIMENT_BATCH_SIZE=10
+
+# YouTube cookies for /play (Netscape cookies.txt). Required on VPS — datacenter
+# IPs get "Sign in to confirm you're not a bot" without them.
+# Prod compose mounts ./secrets → /run/secrets and sets this path.
+# YOUTUBE_COOKIES_FILE=/run/secrets/youtube.cookies

--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,12 @@ ENV/
 env.bak/
 venv.bak/
 
+# YouTube / yt-dlp cookies (never commit)
+secrets/*
+!secrets/.gitkeep
+*.cookies
+cookies.txt
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Join a voice channel, then:
 
 Requires FFmpeg + yt-dlp in the container (installed via the Dockerfile / `requirements.txt`). The bot needs **Connect** and **Speak** permissions in the voice channel.
 
+Production also needs a Netscape `youtube.cookies` file (logged-in Google/YouTube account) at `secrets/youtube.cookies` on the VPS — YouTube blocks anonymous datacenter IPs. Set `YOUTUBE_COOKIES_FILE` (compose defaults to `/run/secrets/youtube.cookies`). Prefer a spare account; refresh cookies when `/play` starts failing bot checks again.
+
 Setup: DinkCoin tables are created with the shared Postgres schema (`deploy/postgres/init.sql` on the dinkboard VPS); `scripts/dinkcoin_schema.sql` is the same DDL for local use.
 
 ## Project Structure

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import re
 from collections import deque
 from dataclasses import dataclass
@@ -41,6 +42,34 @@ YDL_OPTIONS = {
     "socket_timeout": YDL_SOCKET_TIMEOUT,
     "cachedir": False,
 }
+
+
+def ydl_options() -> dict:
+    """Build yt-dlp options, attaching Netscape cookies when configured."""
+    opts = dict(YDL_OPTIONS)
+    cookiefile = os.getenv("YOUTUBE_COOKIES_FILE", "").strip()
+    if not cookiefile:
+        return opts
+    if os.path.isfile(cookiefile):
+        opts["cookiefile"] = cookiefile
+    else:
+        logger.warning("YOUTUBE_COOKIES_FILE set but file missing: %s", cookiefile)
+    return opts
+
+
+def _yt_dlp_user_message(exc: BaseException) -> str:
+    text = str(exc).lower()
+    if (
+        "sign in to confirm" in text
+        or "not a bot" in text
+        or "login_required" in text
+        or "cookies" in text
+    ):
+        return (
+            "YouTube blocked this request (bot check). "
+            "An admin needs to refresh the YouTube cookies on the server."
+        )
+    return "Couldn't find that on YouTube. Try a different search or paste a video URL."
 
 FFMPEG_OPTIONS = {
     "before_options": (
@@ -137,7 +166,7 @@ def _webpage_url_from_entry(entry: dict) -> str:
 def extract_track_info(query: str) -> dict:
     """Resolve a URL or search query to track metadata (no download)."""
     ydl_query = to_ydl_query(query)
-    with yt_dlp.YoutubeDL(YDL_OPTIONS) as ydl:
+    with yt_dlp.YoutubeDL(ydl_options()) as ydl:
         info = ydl.extract_info(ydl_query, download=False)
     if info is None:
         raise ValueError("No results.")
@@ -153,7 +182,7 @@ def extract_stream_url(webpage_url: str) -> str:
     """Fetch a fresh audio stream URL for an already-resolved video page."""
     if not is_youtube_url(webpage_url):
         raise ValueError("Refusing to stream a non-YouTube URL.")
-    with yt_dlp.YoutubeDL(YDL_OPTIONS) as ydl:
+    with yt_dlp.YoutubeDL(ydl_options()) as ydl:
         info = ydl.extract_info(webpage_url, download=False)
     if info is None:
         raise ValueError("Could not get an audio stream for that video.")
@@ -182,6 +211,14 @@ class Music(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._players: Dict[int, GuildPlayer] = {}
+        cookiefile = os.getenv("YOUTUBE_COOKIES_FILE", "").strip()
+        if cookiefile and os.path.isfile(cookiefile):
+            logger.info("YouTube cookies enabled (%s)", cookiefile)
+        else:
+            logger.warning(
+                "YouTube cookies not loaded — /play may hit bot checks. "
+                "Set YOUTUBE_COOKIES_FILE to a Netscape cookies.txt path."
+            )
 
     def _player(self, guild_id: int) -> GuildPlayer:
         if guild_id not in self._players:
@@ -323,11 +360,9 @@ class Music(commands.Cog):
 
             try:
                 info = await asyncio.to_thread(extract_track_info, query)
-            except Exception:
+            except Exception as exc:
                 logger.exception("yt-dlp failed for query %r", query)
-                await ctx.send(
-                    "Couldn't find that on YouTube. Try a different search or paste a video URL."
-                )
+                await ctx.send(_yt_dlp_user_message(exc))
                 return
 
             track = Track(

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,11 @@ services:
     environment:
       SQL_HOST: postgres
       SQL_PORT: "5432"
+      YOUTUBE_COOKIES_FILE: /run/secrets/youtube.cookies
+    volumes:
+      # Netscape cookies.txt for yt-dlp (create on host before first deploy):
+      #   /opt/apps/discordbot/secrets/youtube.cookies
+      - ./secrets:/run/secrets:ro
     networks:
       - dinkboard
 

--- a/tests/test_music_commands.py
+++ b/tests/test_music_commands.py
@@ -7,12 +7,14 @@ from cogs.music import (
     Music,
     Track,
     _webpage_url_from_entry,
+    _yt_dlp_user_message,
     extract_stream_url,
     extract_track_info,
     format_duration,
     is_youtube_url,
     safe_title,
     to_ydl_query,
+    ydl_options,
 )
 from tests.reporting import SECTION_COMMANDS
 
@@ -122,6 +124,31 @@ def test_extract_track_info_empty_search_raises(mock_ydl_cls, report):
         raised = True
     report.record("empty search raises", True, raised, section=SECTION_COMMANDS)
     assert raised
+
+
+def test_ydl_options_attaches_cookiefile(tmp_path, monkeypatch, report):
+    cookies = tmp_path / "youtube.cookies"
+    cookies.write_text("# Netscape HTTP Cookie File\n", encoding="utf-8")
+    monkeypatch.setenv("YOUTUBE_COOKIES_FILE", str(cookies))
+    opts = ydl_options()
+    report.record("cookiefile set", str(cookies), opts.get("cookiefile"), section=SECTION_COMMANDS)
+    assert opts["cookiefile"] == str(cookies)
+
+
+def test_ydl_options_skips_missing_cookiefile(tmp_path, monkeypatch, report):
+    missing = tmp_path / "missing.cookies"
+    monkeypatch.setenv("YOUTUBE_COOKIES_FILE", str(missing))
+    opts = ydl_options()
+    report.record("missing cookiefile omitted", False, "cookiefile" in opts, section=SECTION_COMMANDS)
+    assert "cookiefile" not in opts
+
+
+def test_yt_dlp_user_message_bot_check(report):
+    msg = _yt_dlp_user_message(
+        Exception("ERROR: [youtube] abc: Sign in to confirm you’re not a bot")
+    )
+    report.record("bot check message", "refresh cookies", msg, section=SECTION_COMMANDS)
+    assert "cookies" in msg.lower()
 
 
 @patch("cogs.music.yt_dlp.YoutubeDL")


### PR DESCRIPTION
## Summary
- Load Netscape cookies via `YOUTUBE_COOKIES_FILE` so yt-dlp can authenticate as a real YouTube account.
- Mount `./secrets` in prod compose (path `/run/secrets/youtube.cookies`).
- Clearer Discord error when YouTube bot-checks the VPS; unit tests for cookie option wiring.

## Ops (before/after merge)
1. Export cookies from a spare Google account (do not commit the file).
2. Place at `/opt/apps/discordbot/secrets/youtube.cookies` on the VPS (`chmod 600`).
3. Merge + deploy, then try `/play`.

## Test plan
- [ ] CI Tests green
- [ ] Cookies file present on VPS
- [ ] `/play` URL and search both start audio after deploy