### PR TITLE
Install Deno for yt-dlp YouTube JS challenges

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,5 +24,6 @@ DINK_MINT_AMOUNT=1
 
 # YouTube cookies for /play (Netscape cookies.txt). Required on VPS — datacenter
 # IPs get "Sign in to confirm you're not a bot" without them.
+# Export AFTER visiting youtube.com while signed in (file should include LOGIN_INFO).
 # Prod compose mounts ./secrets → /run/secrets and sets this path.
 # YOUTUBE_COOKIES_FILE=/run/secrets/youtube.cookies

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,18 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# Deno is required for yt-dlp YouTube JS challenges (EJS).
+ARG DENO_VERSION=2.4.3
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc libpq-dev ffmpeg \
+    gcc libpq-dev ffmpeg curl unzip ca-certificates \
+    && curl -fsSL "https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip" \
+      -o /tmp/deno.zip \
+    && unzip -o /tmp/deno.zip -d /usr/local/bin \
+    && chmod +x /usr/local/bin/deno \
+    && rm /tmp/deno.zip \
+    && apt-get purge -y curl unzip \
+    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/README.md
+++ b/README.md
@@ -101,7 +101,12 @@ Join a voice channel, then:
 
 Requires FFmpeg + yt-dlp in the container (installed via the Dockerfile / `requirements.txt`). The bot needs **Connect** and **Speak** permissions in the voice channel.
 
-Production also needs a Netscape `youtube.cookies` file (logged-in Google/YouTube account) at `secrets/youtube.cookies` on the VPS — YouTube blocks anonymous datacenter IPs. Set `YOUTUBE_COOKIES_FILE` (compose defaults to `/run/secrets/youtube.cookies`). Prefer a spare account; refresh cookies when `/play` starts failing bot checks again.
+Production needs:
+
+1. **Deno** in the Docker image (for yt-dlp YouTube JS challenges).
+2. A Netscape `youtube.cookies` file from a logged-in Google/YouTube account at `secrets/youtube.cookies` on the VPS.
+
+Export cookies only after opening [youtube.com](https://www.youtube.com) while signed in (play a video once). Prefer a spare account. Refresh when `/play` hits bot checks again.
 
 Setup: DinkCoin tables are created with the shared Postgres schema (`deploy/postgres/init.sql` on the dinkboard VPS); `scripts/dinkcoin_schema.sql` is the same DDL for local use.
 

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import re
+import shutil
 from collections import deque
 from dataclasses import dataclass
 from typing import Deque, Dict, Optional
@@ -22,6 +23,8 @@ logger = logging.getLogger(__name__)
 
 MAX_QUEUE_SIZE = 50
 YDL_SOCKET_TIMEOUT = 20
+# Writable copy — secrets mount is read-only and yt-dlp tries to refresh cookies.
+_RUNTIME_COOKIE_PATH = "/tmp/youtube.cookies"
 
 YOUTUBE_HOSTS = frozenset({
     "youtube.com",
@@ -41,19 +44,33 @@ YDL_OPTIONS = {
     "source_address": "0.0.0.0",
     "socket_timeout": YDL_SOCKET_TIMEOUT,
     "cachedir": False,
+    # Allow Deno to fetch EJS challenge scripts when the bundled package is stale.
+    "remote_components": {"ejs:npm"},
 }
+
+
+def _resolved_cookiefile() -> Optional[str]:
+    """Return a writable cookie path, or None if cookies are not configured."""
+    src = os.getenv("YOUTUBE_COOKIES_FILE", "").strip()
+    if not src:
+        return None
+    if not os.path.isfile(src):
+        logger.warning("YOUTUBE_COOKIES_FILE set but file missing: %s", src)
+        return None
+    try:
+        shutil.copy2(src, _RUNTIME_COOKIE_PATH)
+    except OSError:
+        logger.exception("Failed to copy YouTube cookies to %s", _RUNTIME_COOKIE_PATH)
+        return None
+    return _RUNTIME_COOKIE_PATH
 
 
 def ydl_options() -> dict:
     """Build yt-dlp options, attaching Netscape cookies when configured."""
     opts = dict(YDL_OPTIONS)
-    cookiefile = os.getenv("YOUTUBE_COOKIES_FILE", "").strip()
-    if not cookiefile:
-        return opts
-    if os.path.isfile(cookiefile):
+    cookiefile = _resolved_cookiefile()
+    if cookiefile:
         opts["cookiefile"] = cookiefile
-    else:
-        logger.warning("YOUTUBE_COOKIES_FILE set but file missing: %s", cookiefile)
     return opts
 
 
@@ -211,8 +228,8 @@ class Music(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._players: Dict[int, GuildPlayer] = {}
-        cookiefile = os.getenv("YOUTUBE_COOKIES_FILE", "").strip()
-        if cookiefile and os.path.isfile(cookiefile):
+        cookiefile = _resolved_cookiefile()
+        if cookiefile:
             logger.info("YouTube cookies enabled (%s)", cookiefile)
         else:
             logger.warning(

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ python-dotenv
 xai-sdk>=1.17.0
 PyNaCl>=1.5.0
 davey>=0.1.0
-yt-dlp>=2024.8.0
+yt-dlp[default]>=2024.8.0

--- a/tests/test_music_commands.py
+++ b/tests/test_music_commands.py
@@ -128,11 +128,14 @@ def test_extract_track_info_empty_search_raises(mock_ydl_cls, report):
 
 def test_ydl_options_attaches_cookiefile(tmp_path, monkeypatch, report):
     cookies = tmp_path / "youtube.cookies"
+    runtime = tmp_path / "runtime.cookies"
     cookies.write_text("# Netscape HTTP Cookie File\n", encoding="utf-8")
     monkeypatch.setenv("YOUTUBE_COOKIES_FILE", str(cookies))
+    monkeypatch.setattr("cogs.music._RUNTIME_COOKIE_PATH", str(runtime))
     opts = ydl_options()
-    report.record("cookiefile set", str(cookies), opts.get("cookiefile"), section=SECTION_COMMANDS)
-    assert opts["cookiefile"] == str(cookies)
+    report.record("cookiefile set", str(runtime), opts.get("cookiefile"), section=SECTION_COMMANDS)
+    assert opts["cookiefile"] == str(runtime)
+    assert runtime.is_file()
 
 
 def test_ydl_options_skips_missing_cookiefile(tmp_path, monkeypatch, report):


### PR DESCRIPTION
## Summary
- Install Deno in the Docker image and use `yt-dlp[default]` (includes EJS scripts).
- Copy YouTube cookies to a writable `/tmp` path so yt-dlp can refresh them (secrets mount is read-only).
- Allow `remote_components: ejs:npm` as a fallback.

## Note
Current VPS cookies are incomplete (no `LOGIN_INFO`). After this merges, re-export cookies while signed into youtube.com and overwrite `secrets/youtube.cookies`.

## Test plan
- [ ] CI Tests green
- [ ] Deploy completes
- [ ] Fresh cookies with `LOGIN_INFO` on VPS
- [ ] `/play` URL works