### PR TITLE
Switch /play to Lavalink + YouTube OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,8 @@ DINK_MINT_AMOUNT=1
 # Messages per Grok request (falls back to per-message scoring if a batch response is bad)
 # SENTIMENT_BATCH_SIZE=10
 
-# YouTube cookies for /play (Netscape cookies.txt). Required on VPS — datacenter
-# IPs get "Sign in to confirm you're not a bot" without them.
-# Export AFTER visiting youtube.com while signed in (file should include LOGIN_INFO).
-# Prod compose mounts ./secrets → /run/secrets and sets this path.
-# YOUTUBE_COOKIES_FILE=/run/secrets/youtube.cookies
+# Lavalink (YouTube /play). Compose sets LAVALINK_URI=http://lavalink:2333.
+# Generate a long random password and use the same value for the Lavalink service.
+LAVALINK_PASSWORD=
+# After first OAuth (see README), paste the refresh token printed in discord-lavalink logs:
+# YOUTUBE_OAUTH_REFRESH_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -119,7 +119,7 @@ ENV/
 env.bak/
 venv.bak/
 
-# YouTube / yt-dlp cookies (never commit)
+# Local secrets (never commit) — cookies leftover from old yt-dlp path
 secrets/*
 !secrets/.gitkeep
 *.cookies

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,8 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Deno is required for yt-dlp YouTube JS challenges (EJS).
-ARG DENO_VERSION=2.4.3
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc libpq-dev ffmpeg curl unzip ca-certificates \
-    && curl -fsSL "https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip" \
-      -o /tmp/deno.zip \
-    && unzip -o /tmp/deno.zip -d /usr/local/bin \
-    && chmod +x /usr/local/bin/deno \
-    && rm /tmp/deno.zip \
-    && apt-get purge -y curl unzip \
-    && apt-get autoremove -y \
+    gcc libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/README.md
+++ b/README.md
@@ -99,14 +99,26 @@ Join a voice channel, then:
 | `/pause` / `/resume` | Pause or resume |
 | `/leave` | Disconnect from voice |
 
-Requires FFmpeg + yt-dlp in the container (installed via the Dockerfile / `requirements.txt`). The bot needs **Connect** and **Speak** permissions in the voice channel.
+Requires **Lavalink** (Java audio node) + the official YouTube plugin with OAuth. The Discord bot talks to Lavalink via Wavelink; it does **not** need yt-dlp, cookies, or a residential proxy for `/play`. The bot needs **Connect** and **Speak** permissions in the voice channel.
 
-Production needs:
+Production setup:
 
-1. **Deno** in the Docker image (for yt-dlp YouTube JS challenges).
-2. A Netscape `youtube.cookies` file from a logged-in Google/YouTube account at `secrets/youtube.cookies` on the VPS.
+1. Put a long random `LAVALINK_PASSWORD` in the VPS `.env` (compose passes it to both `lavalink` and `discord-bot`).
+2. Deploy: `cd /opt/apps/discordbot && ./deploy/deploy.sh` (starts `discord-lavalink` + `discord-bot`).
+3. Complete **YouTube OAuth once** with a **throwaway Google account** (never your main account):
 
-Export cookies only after opening [youtube.com](https://www.youtube.com) while signed in (play a video once). Prefer a spare account. Refresh when `/play` hits bot checks again.
+```bash
+# Watch for the device login URL/code:
+ssh dinkboard 'docker logs -f discord-lavalink' | grep -iE 'oauth|device|https://www.youtube.com'
+
+# Open the URL, enter the code, authorize the spare account.
+# Lavalink prints a refresh token — save it:
+#   YOUTUBE_OAUTH_REFRESH_TOKEN=...
+# in /opt/apps/discordbot/.env, then:
+ssh dinkboard 'cd /opt/apps/discordbot && docker compose -f docker-compose.prod.yml up -d lavalink'
+```
+
+Locally: run Lavalink (same `deploy/lavalink/application.yml`), set `LAVALINK_URI=http://127.0.0.1:2333` and `LAVALINK_PASSWORD`, then start the bot.
 
 Setup: DinkCoin tables are created with the shared Postgres schema (`deploy/postgres/init.sql` on the dinkboard VPS); `scripts/dinkcoin_schema.sql` is the same DDL for local use.
 
@@ -118,7 +130,7 @@ Setup: DinkCoin tables are created with the shared Postgres schema (`deploy/post
   - `ai.py`: AI-related commands including ChatGPT integration and DALL·E 3 image generation.
   - `first.py`: Commands for tracking and managing first messages of the day.
   - `dinkcoin.py`: DinkCoin balance, ledger, and peer-to-peer transfers.
-  - `music.py`: YouTube voice playback (`/play` URL or search) via yt-dlp + FFmpeg.
+  - `music.py`: YouTube voice playback (`/play` URL or search) via Lavalink + Wavelink.
   - `misc.py`: Miscellaneous utility commands.
   - `server.py`: Server management and dashboard-related commands.
   - `utility.py`: General utility commands.
@@ -126,7 +138,8 @@ Setup: DinkCoin tables are created with the shared Postgres schema (`deploy/post
   - `constants.py`: Constants and configuration values.
   - `db.py`: Database operations for logging messages and events.
 - `scripts/dinkcoin_schema.sql`: Postgres tables for the DINK ledger.
-- `Dockerfile` / `docker-compose.prod.yml`: VPS container deploy (joins the dinkboard Docker network).
+- `Dockerfile` / `docker-compose.prod.yml`: VPS containers for the bot + Lavalink (joins the dinkboard Docker network).
+- `deploy/lavalink/application.yml`: Lavalink + youtube-source OAuth config.
 - `requirements.txt`: Python dependencies required for the project.
 - `requirements-dev.txt`: Test dependencies (pytest, pytest-asyncio).
 - `tests/`: Pytest suite (mocked command tests, unit tests, and live smoke tests).

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -1,4 +1,4 @@
-"""YouTube voice playback via yt-dlp + FFmpeg (URL or search query)."""
+"""YouTube voice playback via Lavalink + Wavelink (URL or search query)."""
 
 from __future__ import annotations
 
@@ -6,14 +6,11 @@ import asyncio
 import logging
 import os
 import re
-import shutil
-from collections import deque
-from dataclasses import dataclass
-from typing import Deque, Dict, Optional
+from typing import Optional
 from urllib.parse import urlparse
 
 import discord
-import yt_dlp
+import wavelink
 from discord import app_commands
 from discord.ext import commands
 
@@ -22,9 +19,6 @@ from utils.interactions import acknowledge
 logger = logging.getLogger(__name__)
 
 MAX_QUEUE_SIZE = 50
-YDL_SOCKET_TIMEOUT = 20
-# Writable copy — secrets mount is read-only and yt-dlp tries to refresh cookies.
-_RUNTIME_COOKIE_PATH = "/tmp/youtube.cookies"
 
 YOUTUBE_HOSTS = frozenset({
     "youtube.com",
@@ -35,79 +29,10 @@ YOUTUBE_HOSTS = frozenset({
     "www.youtu.be",
 })
 
-YDL_OPTIONS = {
-    "format": "bestaudio/best",
-    "noplaylist": True,
-    "quiet": True,
-    "no_warnings": True,
-    "default_search": "ytsearch",
-    "source_address": "0.0.0.0",
-    "socket_timeout": YDL_SOCKET_TIMEOUT,
-    "cachedir": False,
-    # Allow Deno to fetch EJS challenge scripts when the bundled package is stale.
-    "remote_components": {"ejs:npm"},
-}
-
-
-def _resolved_cookiefile() -> Optional[str]:
-    """Return a writable cookie path, or None if cookies are not configured."""
-    src = os.getenv("YOUTUBE_COOKIES_FILE", "").strip()
-    if not src:
-        return None
-    if not os.path.isfile(src):
-        logger.warning("YOUTUBE_COOKIES_FILE set but file missing: %s", src)
-        return None
-    try:
-        shutil.copy2(src, _RUNTIME_COOKIE_PATH)
-    except OSError:
-        logger.exception("Failed to copy YouTube cookies to %s", _RUNTIME_COOKIE_PATH)
-        return None
-    return _RUNTIME_COOKIE_PATH
-
-
-def ydl_options() -> dict:
-    """Build yt-dlp options, attaching Netscape cookies when configured."""
-    opts = dict(YDL_OPTIONS)
-    cookiefile = _resolved_cookiefile()
-    if cookiefile:
-        opts["cookiefile"] = cookiefile
-    return opts
-
-
-def _yt_dlp_user_message(exc: BaseException) -> str:
-    text = str(exc).lower()
-    if (
-        "sign in to confirm" in text
-        or "not a bot" in text
-        or "login_required" in text
-        or "cookies" in text
-    ):
-        return (
-            "YouTube blocked this request (bot check). "
-            "An admin needs to refresh the YouTube cookies on the server."
-        )
-    return "Couldn't find that on YouTube. Try a different search or paste a video URL."
-
-FFMPEG_OPTIONS = {
-    "before_options": (
-        "-nostdin -reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5"
-    ),
-    "options": "-vn",
-}
-
 _YOUTUBE_HOST_RE = re.compile(
     r"^(?:https?://)?(?:www\.)?(?:music\.)?(?:m\.)?(?:youtube\.com|youtu\.be)/",
     re.IGNORECASE,
 )
-
-
-@dataclass(frozen=True)
-class Track:
-    title: str
-    webpage_url: str
-    duration: Optional[int]
-    requester_id: int
-    requester_name: str
 
 
 def is_youtube_url(query: str) -> bool:
@@ -124,7 +49,6 @@ def is_youtube_url(query: str) -> bool:
     host = (parsed.hostname or "").lower()
     if host not in YOUTUBE_HOSTS:
         return False
-    # Require a video path or query so bare "youtube.com/" is not treated as a URL play.
     if host.endswith("youtu.be"):
         return bool(parsed.path.strip("/"))
     path = parsed.path or ""
@@ -133,17 +57,17 @@ def is_youtube_url(query: str) -> bool:
     )
 
 
-def to_ydl_query(query: str) -> str:
-    """Map user input to a yt-dlp URL or ytsearch1 query."""
+def to_search_query(query: str) -> str:
+    """Normalize user input for Wavelink search (URL or bare search text)."""
     text = query.strip()
     if is_youtube_url(text):
         if "://" not in text:
             return f"https://{text}"
         return text
-    return f"ytsearch1:{text}"
+    return text
 
 
-def format_duration(seconds: Optional[int]) -> str:
+def format_duration(seconds: Optional[int | float]) -> str:
     if seconds is None:
         return "?:??"
     seconds = max(0, int(seconds))
@@ -159,90 +83,75 @@ def safe_title(title: str) -> str:
     return discord.utils.escape_markdown(title).replace("[", "").replace("]", "")
 
 
-def _pick_entry(info: dict) -> dict:
-    if "entries" in info:
-        for entry in info["entries"]:
-            if entry:
-                return entry
-        raise ValueError("No search results found.")
-    return info
+def _track_duration_seconds(track: wavelink.Playable) -> Optional[int]:
+    length = getattr(track, "length", None)
+    if length is None:
+        return None
+    # Wavelink lengths are milliseconds.
+    try:
+        return max(0, int(length) // 1000)
+    except (TypeError, ValueError):
+        return None
 
 
-def _webpage_url_from_entry(entry: dict) -> str:
-    """Prefer a stable watch URL; never fall back to expiring CDN stream URLs."""
-    for key in ("webpage_url", "original_url"):
-        value = entry.get(key)
-        if value and is_youtube_url(value):
-            return value if "://" in value else f"https://{value}"
-    video_id = entry.get("id")
-    if video_id and re.fullmatch(r"[\w-]{6,}", str(video_id)):
-        return f"https://www.youtube.com/watch?v={video_id}"
-    raise ValueError("Could not resolve a playable YouTube URL.")
+def _track_url(track: wavelink.Playable) -> str:
+    uri = getattr(track, "uri", None)
+    if uri and is_youtube_url(str(uri)):
+        return str(uri) if "://" in str(uri) else f"https://{uri}"
+    identifier = getattr(track, "identifier", None)
+    if identifier and re.fullmatch(r"[\w-]{6,}", str(identifier)):
+        return f"https://www.youtube.com/watch?v={identifier}"
+    return str(uri or "https://www.youtube.com")
 
 
-def extract_track_info(query: str) -> dict:
-    """Resolve a URL or search query to track metadata (no download)."""
-    ydl_query = to_ydl_query(query)
-    with yt_dlp.YoutubeDL(ydl_options()) as ydl:
-        info = ydl.extract_info(ydl_query, download=False)
-    if info is None:
-        raise ValueError("No results.")
-    entry = _pick_entry(info)
-    return {
-        "title": entry.get("title") or "Unknown title",
-        "webpage_url": _webpage_url_from_entry(entry),
-        "duration": entry.get("duration"),
-    }
-
-
-def extract_stream_url(webpage_url: str) -> str:
-    """Fetch a fresh audio stream URL for an already-resolved video page."""
-    if not is_youtube_url(webpage_url):
-        raise ValueError("Refusing to stream a non-YouTube URL.")
-    with yt_dlp.YoutubeDL(ydl_options()) as ydl:
-        info = ydl.extract_info(webpage_url, download=False)
-    if info is None:
-        raise ValueError("Could not get an audio stream for that video.")
-    entry = _pick_entry(info)
-    stream_url = entry.get("url")
-    if not stream_url:
-        raise ValueError("Could not get an audio stream for that video.")
-    return stream_url
-
-
-class GuildPlayer:
-    """In-memory queue + playback state for one guild."""
-
-    def __init__(self, guild_id: int):
-        self.guild_id = guild_id
-        self.queue: Deque[Track] = deque()
-        self.current: Optional[Track] = None
-        self.lock = asyncio.Lock()
-        # Bumped on stop/leave so in-flight yt-dlp extracts do not start audio.
-        self.generation = 0
+def _lavalink_user_message(exc: BaseException) -> str:
+    text = str(exc).lower()
+    if "oauth" in text or "login" in text or "sign in" in text or "not a bot" in text:
+        return (
+            "YouTube needs Lavalink OAuth. An admin should check "
+            "`discord-lavalink` logs for the device login URL, then set "
+            "`YOUTUBE_OAUTH_REFRESH_TOKEN`."
+        )
+    if "nodisconnected" in text.replace(" ", "") or "no nodes" in text or "node" in text and "connect" in text:
+        return "Music backend is offline. Try again in a moment."
+    return "Couldn't find that on YouTube. Try a different search or paste a video URL."
 
 
 class Music(commands.Cog):
-    """Play YouTube audio in a voice channel (URL or search)."""
+    """Play YouTube audio in a voice channel via Lavalink (URL or search)."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        self._players: Dict[int, GuildPlayer] = {}
-        cookiefile = _resolved_cookiefile()
-        if cookiefile:
-            logger.info("YouTube cookies enabled (%s)", cookiefile)
-        else:
+
+    async def cog_load(self) -> None:
+        uri = os.getenv("LAVALINK_URI", "http://127.0.0.1:2333").strip()
+        password = os.getenv("LAVALINK_PASSWORD", "").strip()
+        if not password:
             logger.warning(
-                "YouTube cookies not loaded — /play may hit bot checks. "
-                "Set YOUTUBE_COOKIES_FILE to a Netscape cookies.txt path."
+                "LAVALINK_PASSWORD is empty — set it in .env to match Lavalink."
             )
+        nodes = [wavelink.Node(identifier="main", uri=uri, password=password or "youshallnotpass")]
+        try:
+            await wavelink.Pool.connect(nodes=nodes, client=self.bot)
+            logger.info("Connected to Lavalink at %s", uri)
+        except Exception:
+            logger.exception("Failed to connect to Lavalink at %s", uri)
 
-    def _player(self, guild_id: int) -> GuildPlayer:
-        if guild_id not in self._players:
-            self._players[guild_id] = GuildPlayer(guild_id)
-        return self._players[guild_id]
+    async def cog_unload(self) -> None:
+        try:
+            await wavelink.Pool.close()
+        except Exception:
+            logger.debug("Lavalink pool close failed", exc_info=True)
 
-    async def _ensure_voice(self, ctx: commands.Context) -> discord.VoiceClient:
+    def _track_line(self, track: wavelink.Playable, requester: str, *, prefix: str = "") -> str:
+        title = safe_title(getattr(track, "title", None) or "Unknown title")
+        duration = format_duration(_track_duration_seconds(track))
+        return (
+            f"{prefix}**{title}** ({duration})\n"
+            f"{_track_url(track)} — {requester}"
+        )
+
+    async def _ensure_player(self, ctx: commands.Context) -> wavelink.Player:
         if ctx.guild is None:
             raise commands.CommandError("This command only works in a server.")
 
@@ -259,99 +168,24 @@ class Music(commands.Cog):
                     "I need **Connect** and **Speak** permissions in that voice channel."
                 )
 
-        voice = ctx.voice_client
+        player = ctx.voice_client
         try:
-            if voice is None:
-                return await channel.connect()
-            if voice.channel != channel:
-                await voice.move_to(channel)
-            return voice
+            if player is None:
+                player = await channel.connect(cls=wavelink.Player, self_deaf=True)
+            elif not isinstance(player, wavelink.Player):
+                await player.disconnect()
+                player = await channel.connect(cls=wavelink.Player, self_deaf=True)
+            elif player.channel != channel:
+                await player.move_to(channel)
         except asyncio.TimeoutError as exc:
             raise commands.CommandError("Timed out joining the voice channel.") from exc
         except discord.ClientException as exc:
             raise commands.CommandError(f"Could not join voice: {exc}") from exc
 
-    def _track_line(self, track: Track, *, prefix: str = "") -> str:
-        title = safe_title(track.title)
-        return (
-            f"{prefix}**{title}** ({format_duration(track.duration)})\n"
-            f"{track.webpage_url} — {track.requester_name}"
-        )
-
-    async def _play_next(self, guild_id: int) -> None:
-        player = self._player(guild_id)
-        guild = self.bot.get_guild(guild_id)
-        if guild is None:
-            async with player.lock:
-                player.current = None
-                player.queue.clear()
-            return
-
-        async with player.lock:
-            voice = guild.voice_client
-            if voice is None or not voice.is_connected():
-                player.current = None
-                player.queue.clear()
-                return
-            # Another starter already owns playback (or pause).
-            if voice.is_playing() or voice.is_paused():
-                return
-            player.current = None
-            if not player.queue:
-                return
-            track = player.queue.popleft()
-            player.current = track
-            generation = player.generation
-
-        try:
-            stream_url = await asyncio.to_thread(extract_stream_url, track.webpage_url)
-        except Exception:
-            logger.exception("Failed to resolve stream for %s", track.webpage_url)
-            async with player.lock:
-                if player.generation != generation:
-                    return
-                if player.current is track:
-                    player.current = None
-            await self._play_next(guild_id)
-            return
-
-        async with player.lock:
-            if player.generation != generation:
-                if player.current is track:
-                    player.current = None
-                return
-            voice = guild.voice_client
-            if voice is None or not voice.is_connected():
-                player.current = None
-                player.queue.clear()
-                return
-            if voice.is_playing() or voice.is_paused():
-                # Lost the race; put the track back at the front.
-                if player.current is track:
-                    player.current = None
-                player.queue.appendleft(track)
-                return
-            try:
-                source = discord.FFmpegOpusAudio(stream_url, **FFMPEG_OPTIONS)
-            except Exception:
-                logger.exception("FFmpeg failed for %s", track.webpage_url)
-                if player.current is track:
-                    player.current = None
-                self.bot.loop.create_task(self._play_next(guild_id))
-                return
-
-            def _after(error: Optional[Exception]) -> None:
-                if error:
-                    logger.error("Playback error in guild %s: %s", guild_id, error)
-                asyncio.run_coroutine_threadsafe(self._play_next(guild_id), self.bot.loop)
-
-            try:
-                voice.play(source, after=_after)
-            except discord.ClientException:
-                logger.exception("voice.play failed in guild %s", guild_id)
-                if player.current is track:
-                    player.current = None
-                player.queue.appendleft(track)
+        assert isinstance(player, wavelink.Player)
+        # Advance the queue when a track ends (no AutoPlay recommendations).
+        player.autoplay = wavelink.AutoPlayMode.partial
+        return player
 
     @commands.hybrid_command(brief="Play a YouTube URL or search query in voice")
     @app_commands.describe(query="YouTube URL or search text (e.g. tubthumping)")
@@ -366,211 +200,155 @@ class Music(commands.Cog):
             await ctx.send("Give me a YouTube URL or something to search for.")
             return
 
-        player = self._player(ctx.guild.id)
-
         async with acknowledge(ctx):
             try:
-                await self._ensure_voice(ctx)
+                player = await self._ensure_player(ctx)
             except commands.CommandError as exc:
                 await ctx.send(str(exc))
                 return
 
             try:
-                info = await asyncio.to_thread(extract_track_info, query)
+                tracks = await wavelink.Playable.search(
+                    to_search_query(query),
+                    source=wavelink.TrackSource.YouTube,
+                )
             except Exception as exc:
-                logger.exception("yt-dlp failed for query %r", query)
-                await ctx.send(_yt_dlp_user_message(exc))
+                logger.exception("Lavalink search failed for query %r", query)
+                await ctx.send(_lavalink_user_message(exc))
                 return
 
-            track = Track(
-                title=info["title"],
-                webpage_url=info["webpage_url"],
-                duration=info.get("duration"),
-                requester_id=ctx.author.id,
-                requester_name=ctx.author.display_name,
-            )
-
-            async with player.lock:
-                voice = ctx.voice_client
-                playing = voice is not None and (
-                    voice.is_playing() or voice.is_paused()
+            if not tracks:
+                await ctx.send(
+                    "Couldn't find that on YouTube. Try a different search or paste a video URL."
                 )
-                active = player.current is not None or playing
-                if active and len(player.queue) >= MAX_QUEUE_SIZE:
+                return
+
+            track = tracks[0] if not isinstance(tracks, wavelink.Playlist) else tracks.tracks[0]
+            requester = ctx.author.display_name
+
+            if player.current is not None or len(player.queue) > 0:
+                if len(player.queue) >= MAX_QUEUE_SIZE:
                     await ctx.send(f"Queue is full ({MAX_QUEUE_SIZE} tracks).")
                     return
-                player.queue.append(track)
+                await player.queue.put_wait(track)
                 position = len(player.queue)
-                # Start when nothing is playing/extracting. A non-empty idle
-                # queue (e.g. after a dropped after-callback) should recover.
-                should_start = player.current is None and not playing
-
-            if should_start:
-                await self._play_next(ctx.guild.id)
-                # If we recovered an older queued item first, still acknowledge
-                # this request as queued when it was not alone in line.
-                if position == 1:
-                    await ctx.send(self._track_line(track, prefix="▶️ **Now playing:** "))
-                else:
-                    await ctx.send(
-                        self._track_line(track, prefix=f"➕ **Queued #{position}:** ")
-                    )
-            else:
                 await ctx.send(
-                    self._track_line(track, prefix=f"➕ **Queued #{position}:** ")
+                    self._track_line(
+                        track,
+                        requester,
+                        prefix=f"Queued **#{position}:** ",
+                    )
                 )
+                return
+
+            await player.play(track)
+            await ctx.send(self._track_line(track, requester, prefix="▶️ **Now playing:** "))
 
     @commands.hybrid_command(brief="Skip the current track")
     async def skip(self, ctx: commands.Context):
-        """Skip the track that is playing now."""
-        if ctx.guild is None or ctx.voice_client is None:
-            await ctx.send("I'm not playing anything.")
+        if ctx.guild is None:
+            await ctx.send("This command only works in a server.")
             return
-        voice = ctx.voice_client
-        if not voice.is_playing() and not voice.is_paused():
-            await ctx.send("I'm not playing anything.")
+        player = ctx.voice_client
+        if not isinstance(player, wavelink.Player) or not player.playing:
+            await ctx.send("Nothing is playing.")
             return
-        voice.stop()
-        await ctx.send("⏭️ Skipped.")
+        await player.skip(force=True)
+        await ctx.send("Skipped.")
 
     @commands.hybrid_command(brief="Stop playback and clear the queue")
     async def stop(self, ctx: commands.Context):
-        """Stop playback and clear the queue (stays in the voice channel)."""
         if ctx.guild is None:
             await ctx.send("This command only works in a server.")
             return
-        player = self._player(ctx.guild.id)
-        async with player.lock:
-            player.generation += 1
-            player.queue.clear()
-            player.current = None
-        voice = ctx.voice_client
-        if voice and (voice.is_playing() or voice.is_paused()):
-            voice.stop()
-        await ctx.send("⏹️ Stopped and cleared the queue.")
+        player = ctx.voice_client
+        if not isinstance(player, wavelink.Player):
+            await ctx.send("I'm not in a voice channel.")
+            return
+        player.queue.clear()
+        await player.stop()
+        await ctx.send("Stopped and cleared the queue.")
 
-    @commands.hybrid_command(brief="Show the upcoming queue")
+    @commands.hybrid_command(brief="Show the queue")
     async def queue(self, ctx: commands.Context):
-        """Show the current track and upcoming queue."""
         if ctx.guild is None:
             await ctx.send("This command only works in a server.")
             return
-        player = self._player(ctx.guild.id)
-        async with player.lock:
-            current = player.current
-            upcoming = list(player.queue)
-
-        if current is None and not upcoming:
+        player = ctx.voice_client
+        if not isinstance(player, wavelink.Player):
+            await ctx.send("Queue is empty.")
+            return
+        if player.current is None and not player.queue:
             await ctx.send("Queue is empty.")
             return
 
-        lines = []
-        if current is not None:
+        lines: list[str] = []
+        if player.current is not None:
             lines.append(
-                f"**Now playing:** **{safe_title(current.title)}** "
-                f"({format_duration(current.duration)})\n{current.webpage_url}"
+                self._track_line(player.current, "now", prefix="▶️ **Now playing:** ")
             )
-        if upcoming:
-            lines.append("**Up next:**")
-            for i, track in enumerate(upcoming[:15], start=1):
-                lines.append(
-                    f"`{i}.` **{safe_title(track.title)}** "
-                    f"({format_duration(track.duration)}) — {track.requester_name}"
-                )
-            remaining = len(upcoming) - 15
-            if remaining > 0:
-                lines.append(f"_…and {remaining} more_")
+        for index, track in enumerate(list(player.queue)[:20], start=1):
+            title = safe_title(getattr(track, "title", None) or "Unknown title")
+            duration = format_duration(_track_duration_seconds(track))
+            lines.append(f"**{index}.** {title} ({duration})")
+        remaining = max(0, len(player.queue) - 20)
+        if remaining:
+            lines.append(f"…and {remaining} more")
         await ctx.send("\n".join(lines))
 
     @commands.hybrid_command(name="np", brief="Show the track playing now")
     async def now_playing(self, ctx: commands.Context):
-        """Show the track that is playing now."""
         if ctx.guild is None:
             await ctx.send("This command only works in a server.")
             return
-        player = self._player(ctx.guild.id)
-        async with player.lock:
-            track = player.current
-        if track is None:
-            await ctx.send("Nothing is playing right now.")
-            return
-        await ctx.send(self._track_line(track, prefix="🎵 **Now playing:** "))
-
-    @commands.hybrid_command(brief="Pause the current track")
-    async def pause(self, ctx: commands.Context):
-        """Pause playback."""
-        if ctx.voice_client is None or not ctx.voice_client.is_playing():
+        player = ctx.voice_client
+        if not isinstance(player, wavelink.Player) or player.current is None:
             await ctx.send("Nothing is playing.")
             return
-        ctx.voice_client.pause()
-        await ctx.send("⏸️ Paused.")
+        await ctx.send(self._track_line(player.current, "now", prefix="▶️ **Now playing:** "))
 
-    @commands.hybrid_command(brief="Resume paused playback")
+    @commands.hybrid_command(brief="Pause playback")
+    async def pause(self, ctx: commands.Context):
+        if ctx.guild is None:
+            await ctx.send("This command only works in a server.")
+            return
+        player = ctx.voice_client
+        if not isinstance(player, wavelink.Player) or not player.playing:
+            await ctx.send("Nothing is playing.")
+            return
+        if player.paused:
+            await ctx.send("Already paused.")
+            return
+        await player.pause(True)
+        await ctx.send("Paused.")
+
+    @commands.hybrid_command(brief="Resume playback")
     async def resume(self, ctx: commands.Context):
-        """Resume paused playback."""
-        if ctx.voice_client is None or not ctx.voice_client.is_paused():
+        if ctx.guild is None:
+            await ctx.send("This command only works in a server.")
+            return
+        player = ctx.voice_client
+        if not isinstance(player, wavelink.Player):
             await ctx.send("Nothing is paused.")
             return
-        ctx.voice_client.resume()
-        await ctx.send("▶️ Resumed.")
+        if not player.paused:
+            await ctx.send("Nothing is paused.")
+            return
+        await player.pause(False)
+        await ctx.send("Resumed.")
 
     @commands.hybrid_command(brief="Leave the voice channel")
     async def leave(self, ctx: commands.Context):
-        """Disconnect from voice and clear the queue."""
         if ctx.guild is None:
             await ctx.send("This command only works in a server.")
             return
-        player = self._player(ctx.guild.id)
-        async with player.lock:
-            player.generation += 1
-            player.queue.clear()
-            player.current = None
-        if ctx.voice_client is not None:
-            await ctx.voice_client.disconnect()
-            await ctx.send("👋 Left the voice channel.")
-        else:
+        player = ctx.voice_client
+        if not isinstance(player, wavelink.Player):
             await ctx.send("I'm not in a voice channel.")
-
-    async def _cleanup_guild_voice(self, guild_id: int) -> None:
-        player = self._players.get(guild_id)
-        if player is None:
             return
-        async with player.lock:
-            player.generation += 1
-            player.queue.clear()
-            player.current = None
-
-    @commands.Cog.listener()
-    async def on_voice_state_update(self, member, before, after):
-        """Clear state on bot disconnect; leave when alone in the channel."""
-        bot_user = self.bot.user
-        if bot_user is None:
-            return
-
-        # Bot was disconnected / moved out of a channel.
-        if member.id == bot_user.id:
-            if before.channel is not None and after.channel is None:
-                await self._cleanup_guild_voice(before.channel.guild.id)
-            return
-
-        # If a human left/moved and the bot is alone, disconnect.
-        channel = before.channel
-        if channel is None:
-            return
-        if after.channel == before.channel:
-            return
-        guild = channel.guild
-        voice = guild.voice_client
-        if voice is None or voice.channel != channel:
-            return
-        humans = [m for m in channel.members if not m.bot]
-        if humans:
-            return
-        await self._cleanup_guild_voice(guild.id)
-        try:
-            await voice.disconnect()
-        except Exception:
-            logger.exception("Failed to auto-disconnect in guild %s", guild.id)
+        player.queue.clear()
+        await player.disconnect()
+        await ctx.send("Left the voice channel.")
 
 
 async def setup(bot: commands.Bot):

--- a/deploy/lavalink/application.yml
+++ b/deploy/lavalink/application.yml
@@ -1,0 +1,70 @@
+server:
+  port: 2333
+  address: 0.0.0.0
+
+lavalink:
+  plugins:
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.18.2"
+      snapshot: false
+  server:
+    # Set LAVALINK_PASSWORD in the VPS .env (shared with the bot).
+    password: "${LAVALINK_PASSWORD}"
+    sources:
+      youtube: false
+      bandcamp: true
+      soundcloud: true
+      twitch: true
+      vimeo: true
+      http: false
+      local: false
+    bufferDurationMs: 400
+    frameBufferDurationMs: 5000
+    opusEncodingQuality: 10
+    resamplingQuality: LOW
+    trackStuckThresholdMs: 10000
+    useSeekGhosting: true
+    youtubePlaylistLoadLimit: 6
+    playerUpdateInterval: 5
+    youtubeSearchEnabled: true
+    soundcloudSearchEnabled: true
+    gc-warnings: true
+
+plugins:
+  youtube:
+    enabled: true
+    allowSearch: true
+    allowDirectVideoIds: true
+    allowDirectPlaylistIds: true
+    clients:
+      - MUSIC
+      - WEB
+      - WEBEMBEDDED
+      - ANDROID_VR
+      - TV
+    oauth:
+      # Device OAuth on first boot (check lavalink logs for the URL/code).
+      # Then put the printed refresh token in YOUTUBE_OAUTH_REFRESH_TOKEN.
+      enabled: true
+      refreshToken: "${YOUTUBE_OAUTH_REFRESH_TOKEN:}"
+
+metrics:
+  prometheus:
+    enabled: false
+
+sentry:
+  dsn: ""
+
+logging:
+  file:
+    path: ./logs/
+  level:
+    root: INFO
+    lavalink: INFO
+    "dev.lavalink.youtube.http.YoutubeOauth2Handler": INFO
+  request:
+    enabled: true
+    includeClientInfo: true
+    includeHeaders: false
+    includeQueryString: true
+    includePayload: true
+    maxPayloadLength: 10000

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,24 +1,40 @@
 # Discord bot — joins the dinkboard Docker network and uses shared Postgres.
 # From /opt/apps/discordbot on the VPS:
 #   docker compose -f docker-compose.prod.yml up --build -d
+#
+# Required in .env (never commit):
+#   LAVALINK_PASSWORD=...
+# Optional after first YouTube OAuth (see README):
+#   YOUTUBE_OAUTH_REFRESH_TOKEN=...
 
 services:
+  lavalink:
+    container_name: discord-lavalink
+    image: ghcr.io/lavalink-devs/lavalink:4
+    restart: unless-stopped
+    environment:
+      LAVALINK_PASSWORD: ${LAVALINK_PASSWORD}
+      YOUTUBE_OAUTH_REFRESH_TOKEN: ${YOUTUBE_OAUTH_REFRESH_TOKEN:-}
+    volumes:
+      - ./deploy/lavalink/application.yml:/opt/Lavalink/application.yml:ro
+    networks:
+      - dinkboard
+
   discord-bot:
     container_name: discord-bot
     build:
       context: .
       dockerfile: Dockerfile
     restart: unless-stopped
+    depends_on:
+      - lavalink
     env_file:
       - .env
     environment:
       SQL_HOST: postgres
       SQL_PORT: "5432"
-      YOUTUBE_COOKIES_FILE: /run/secrets/youtube.cookies
-    volumes:
-      # Netscape cookies.txt for yt-dlp (create on host before first deploy):
-      #   /opt/apps/discordbot/secrets/youtube.cookies
-      - ./secrets:/run/secrets:ro
+      LAVALINK_URI: http://lavalink:2333
+      LAVALINK_PASSWORD: ${LAVALINK_PASSWORD}
     networks:
       - dinkboard
 

--- a/docs/self_knowledge/music.md
+++ b/docs/self_knowledge/music.md
@@ -3,6 +3,9 @@
 Play YouTube audio in a voice channel. Join a voice channel first, then use
 `/play` with either a **YouTube URL** or a **search phrase**.
 
+Audio is fetched by **Lavalink** (YouTube plugin + OAuth), not by the Discord
+bot process itself.
+
 ## Play — `/play`
 
 - `/play https://youtu.be/...` — play that video's audio

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ python-dotenv
 xai-sdk>=1.17.0
 PyNaCl>=1.5.0
 davey>=0.1.0
-yt-dlp[default]>=2024.8.0
+wavelink>=3.5.0

--- a/tests/test_music_commands.py
+++ b/tests/test_music_commands.py
@@ -1,30 +1,20 @@
-"""Unit tests for music helpers and command edge cases."""
+"""Unit tests for music helpers and command edge cases (Lavalink/Wavelink)."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import wavelink
 
 from cogs.music import (
     MAX_QUEUE_SIZE,
     Music,
-    Track,
-    _webpage_url_from_entry,
-    _yt_dlp_user_message,
-    extract_stream_url,
-    extract_track_info,
+    _lavalink_user_message,
     format_duration,
     is_youtube_url,
     safe_title,
-    to_ydl_query,
-    ydl_options,
+    to_search_query,
 )
 from tests.reporting import SECTION_COMMANDS
-
-
-def _ydl_mock(extract_return):
-    mock_ydl = MagicMock()
-    mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
-    mock_ydl.__exit__ = MagicMock(return_value=False)
-    mock_ydl.extract_info.return_value = extract_return
-    return mock_ydl
 
 
 def test_is_youtube_url_accepts_common_forms(report):
@@ -34,136 +24,49 @@ def test_is_youtube_url_accepts_common_forms(report):
         ("youtube.com/watch?v=dQw4w9WgXcQ", True),
         ("https://music.youtube.com/watch?v=dQw4w9WgXcQ", True),
         ("https://www.youtube.com/shorts/abc123xyz00", True),
-        ("tubthumping", False),
-        ("never gonna give you up", False),
+        ("not a url", False),
         ("https://example.com/watch?v=dQw4w9WgXcQ", False),
-        ("https://vimeo.com/123", False),
         ("https://youtube.com/", False),
-        ("check out https://youtu.be/dQw4w9WgXcQ please", False),
+        ("tubthumping", False),
         ("youtube.com/watch?v=dQw4w9WgXcQ and more", False),
     ]
     for value, expected in cases:
         actual = is_youtube_url(value)
         report.record(f"is_youtube_url({value!r})", expected, actual, section=SECTION_COMMANDS)
-        assert actual is expected, value
+        assert actual is expected
 
 
-def test_to_ydl_query_url_vs_search(report):
-    url = "https://youtu.be/dQw4w9WgXcQ"
-    assert to_ydl_query(url) == url
-    report.record("to_ydl_query(url)", url, to_ydl_query(url), section=SECTION_COMMANDS)
-
-    search = to_ydl_query("tubthumping")
-    expected = "ytsearch1:tubthumping"
-    report.record("to_ydl_query(search)", expected, search, section=SECTION_COMMANDS)
-    assert search == expected
-
-    bare = to_ydl_query("youtube.com/watch?v=dQw4w9WgXcQ")
+def test_to_search_query(report):
+    assert to_search_query("tubthumping") == "tubthumping"
+    report.record("search text", "tubthumping", to_search_query("tubthumping"), section=SECTION_COMMANDS)
+    bare = to_search_query("youtube.com/watch?v=dQw4w9WgXcQ")
+    report.record("bare url gets scheme", True, bare.startswith("https://"), section=SECTION_COMMANDS)
     assert bare.startswith("https://")
-    report.record("to_ydl_query(bare host)", "https://…", bare, section=SECTION_COMMANDS)
-
-    # Sentences must not be treated as URLs.
-    assert to_ydl_query("play https://youtu.be/dQw4w9WgXcQ").startswith("ytsearch1:")
 
 
 def test_format_duration(report):
     assert format_duration(None) == "?:??"
-    assert format_duration(0) == "0:00"
     assert format_duration(65) == "1:05"
     assert format_duration(3661) == "1:01:01"
     report.record("format_duration(65)", "1:05", format_duration(65), section=SECTION_COMMANDS)
 
 
-def test_safe_title_strips_link_breakers(report):
-    actual = safe_title("Song [Live] (Official)")
-    report.record("safe_title", "no brackets", actual, section=SECTION_COMMANDS)
+def test_safe_title(report):
+    actual = safe_title("Song [Live] *wow*")
+    report.record("safe_title strips brackets", True, "[" not in actual and "]" not in actual, section=SECTION_COMMANDS)
     assert "[" not in actual and "]" not in actual
 
 
-def test_webpage_url_prefers_watch_url_not_cdn(report):
-    entry = {
-        "id": "dQw4w9WgXcQ",
-        "url": "https://googlevideo.com/videoplayback?expire=1",
-        "title": "Rick Roll",
-    }
-    url = _webpage_url_from_entry(entry)
-    report.record("webpage from id", "https://www.youtube.com/watch?v=dQw4w9WgXcQ", url, section=SECTION_COMMANDS)
-    assert url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+def test_lavalink_user_message_oauth(report):
+    msg = _lavalink_user_message(Exception("This video requires login / OAuth"))
+    report.record("oauth message", "OAuth", msg, section=SECTION_COMMANDS)
+    assert "oauth" in msg.lower()
 
 
-@patch("cogs.music.yt_dlp.YoutubeDL")
-def test_extract_track_info_search_uses_first_entry(mock_ydl_cls, report):
-    mock_ydl_cls.return_value = _ydl_mock({
-        "entries": [
-            {
-                "id": "abc123xyz00",
-                "title": "Tubthumping",
-                "webpage_url": "https://www.youtube.com/watch?v=abc123xyz00",
-                "duration": 271,
-                "url": "https://googlevideo.com/stream",
-            }
-        ]
-    })
-
-    info = extract_track_info("tubthumping")
-    mock_ydl_cls.return_value.extract_info.assert_called_once_with(
-        "ytsearch1:tubthumping", download=False
-    )
-    assert info["title"] == "Tubthumping"
-    assert info["webpage_url"] == "https://www.youtube.com/watch?v=abc123xyz00"
-    report.record("extract search title", "Tubthumping", info["title"], section=SECTION_COMMANDS)
-
-
-@patch("cogs.music.yt_dlp.YoutubeDL")
-def test_extract_track_info_empty_search_raises(mock_ydl_cls, report):
-    mock_ydl_cls.return_value = _ydl_mock({"entries": []})
-    try:
-        extract_track_info("zzznonsensequeryzzz")
-        raised = False
-    except ValueError:
-        raised = True
-    report.record("empty search raises", True, raised, section=SECTION_COMMANDS)
-    assert raised
-
-
-def test_ydl_options_attaches_cookiefile(tmp_path, monkeypatch, report):
-    cookies = tmp_path / "youtube.cookies"
-    runtime = tmp_path / "runtime.cookies"
-    cookies.write_text("# Netscape HTTP Cookie File\n", encoding="utf-8")
-    monkeypatch.setenv("YOUTUBE_COOKIES_FILE", str(cookies))
-    monkeypatch.setattr("cogs.music._RUNTIME_COOKIE_PATH", str(runtime))
-    opts = ydl_options()
-    report.record("cookiefile set", str(runtime), opts.get("cookiefile"), section=SECTION_COMMANDS)
-    assert opts["cookiefile"] == str(runtime)
-    assert runtime.is_file()
-
-
-def test_ydl_options_skips_missing_cookiefile(tmp_path, monkeypatch, report):
-    missing = tmp_path / "missing.cookies"
-    monkeypatch.setenv("YOUTUBE_COOKIES_FILE", str(missing))
-    opts = ydl_options()
-    report.record("missing cookiefile omitted", False, "cookiefile" in opts, section=SECTION_COMMANDS)
-    assert "cookiefile" not in opts
-
-
-def test_yt_dlp_user_message_bot_check(report):
-    msg = _yt_dlp_user_message(
-        Exception("ERROR: [youtube] abc: Sign in to confirm you’re not a bot")
-    )
-    report.record("bot check message", "refresh cookies", msg, section=SECTION_COMMANDS)
-    assert "cookies" in msg.lower()
-
-
-@patch("cogs.music.yt_dlp.YoutubeDL")
-def test_extract_stream_url_rejects_non_youtube(mock_ydl_cls, report):
-    try:
-        extract_stream_url("https://example.com/audio.mp3")
-        rejected = False
-    except ValueError:
-        rejected = True
-    report.record("reject non-youtube stream", True, rejected, section=SECTION_COMMANDS)
-    assert rejected
-    mock_ydl_cls.assert_not_called()
+def test_lavalink_user_message_generic(report):
+    msg = _lavalink_user_message(Exception("something else"))
+    report.record("generic message", "Couldn't find", msg, section=SECTION_COMMANDS)
+    assert "couldn't find" in msg.lower()
 
 
 async def test_play_requires_voice_channel(report, mock_bot, mock_ctx):
@@ -176,132 +79,83 @@ async def test_play_requires_voice_channel(report, mock_bot, mock_ctx):
     cog = Music(mock_bot)
     await cog.play.callback(cog, mock_ctx, query="tubthumping")
     actual = mock_ctx.send.call_args.args[0]
-    report.record("play without VC", "Join a voice channel", actual, section=SECTION_COMMANDS)
+    report.record("play without voice", "Join a voice channel", actual, section=SECTION_COMMANDS)
     assert "Join a voice channel" in actual
 
 
 async def test_play_queues_when_busy(report, mock_bot, mock_ctx):
     mock_ctx.guild = MagicMock()
-    mock_ctx.guild.id = 9
+    mock_ctx.guild.id = 2
     mock_ctx.guild.me = None
-    voice_state = MagicMock()
-    voice_state.channel = MagicMock()
-    mock_ctx.author.voice = voice_state
-    mock_ctx.voice_client = MagicMock()
-    mock_ctx.voice_client.is_playing.return_value = True
-    mock_ctx.voice_client.is_paused.return_value = False
-    mock_ctx.voice_client.channel = voice_state.channel
+    mock_ctx.author.voice = MagicMock()
+    mock_ctx.author.voice.channel = MagicMock()
+    mock_ctx.author.display_name = "Alex"
+
+    player = MagicMock(spec=wavelink.Player)
+    player.playing = True
+    player.paused = False
+    player.current = MagicMock()
+    player.queue = MagicMock()
+    player.queue.__len__ = MagicMock(return_value=1)
+    player.queue.put_wait = AsyncMock()
+    mock_ctx.voice_client = player
+
+    track = MagicMock()
+    track.title = "Song"
+    track.length = 120000
+    track.uri = "https://www.youtube.com/watch?v=abc123xyz00"
+    track.identifier = "abc123xyz00"
 
     cog = Music(mock_bot)
-    player = cog._player(9)
-    player.current = Track("Current", "https://youtu.be/cur", 10, 1, "A")
+    with patch.object(cog, "_ensure_player", AsyncMock(return_value=player)):
+        with patch("cogs.music.wavelink.Playable.search", AsyncMock(return_value=[track])):
+            await cog.play.callback(cog, mock_ctx, query="tubthumping")
 
-    with patch(
-        "cogs.music.extract_track_info",
-        return_value={
-            "title": "Next Up",
-            "webpage_url": "https://www.youtube.com/watch?v=next123456",
-            "duration": 12,
-        },
-    ):
-        await cog.play.callback(cog, mock_ctx, query="next song")
-
+    player.queue.put_wait.assert_awaited_once_with(track)
+    player.play.assert_not_called()
     actual = mock_ctx.send.call_args.args[0]
-    report.record("play while busy", "Queued", actual, section=SECTION_COMMANDS)
+    report.record("queued while busy", True, "Queued" in actual, section=SECTION_COMMANDS)
     assert "Queued" in actual
-    assert len(player.queue) == 1
-    assert player.queue[0].title == "Next Up"
 
 
-async def test_play_respects_queue_limit(report, mock_bot, mock_ctx):
+async def test_play_starts_when_idle(report, mock_bot, mock_ctx):
     mock_ctx.guild = MagicMock()
-    mock_ctx.guild.id = 11
+    mock_ctx.guild.id = 3
     mock_ctx.guild.me = None
-    voice_state = MagicMock()
-    voice_state.channel = MagicMock()
-    mock_ctx.author.voice = voice_state
-    mock_ctx.voice_client = MagicMock()
-    mock_ctx.voice_client.is_playing.return_value = True
-    mock_ctx.voice_client.is_paused.return_value = False
-    mock_ctx.voice_client.channel = voice_state.channel
+    mock_ctx.author.voice = MagicMock()
+    mock_ctx.author.display_name = "Alex"
+
+    player = MagicMock(spec=wavelink.Player)
+    player.playing = False
+    player.paused = False
+    player.current = None
+    player.queue = MagicMock()
+    player.queue.__bool__ = MagicMock(return_value=False)
+    player.queue.__len__ = MagicMock(return_value=0)
+    player.play = AsyncMock()
+    mock_ctx.voice_client = player
+
+    track = MagicMock()
+    track.title = "Tubthumping"
+    track.length = 213000
+    track.uri = "https://www.youtube.com/watch?v=2H5uWRjFsGc"
+    track.identifier = "2H5uWRjFsGc"
 
     cog = Music(mock_bot)
-    player = cog._player(11)
-    player.current = Track("Current", "https://youtu.be/cur", 10, 1, "A")
-    for i in range(MAX_QUEUE_SIZE):
-        player.queue.append(Track(f"T{i}", "https://youtu.be/x", 1, 1, "A"))
+    with patch.object(cog, "_ensure_player", AsyncMock(return_value=player)):
+        with patch("cogs.music.wavelink.Playable.search", AsyncMock(return_value=[track])):
+            await cog.play.callback(cog, mock_ctx, query="tubthumping")
 
-    with patch(
-        "cogs.music.extract_track_info",
-        return_value={
-            "title": "Overflow",
-            "webpage_url": "https://www.youtube.com/watch?v=overflow01",
-            "duration": 1,
-        },
-    ):
-        await cog.play.callback(cog, mock_ctx, query="overflow")
-
+    player.play.assert_awaited_once_with(track)
     actual = mock_ctx.send.call_args.args[0]
-    report.record("queue full", "Queue is full", actual, section=SECTION_COMMANDS)
-    assert "Queue is full" in actual
-    assert len(player.queue) == MAX_QUEUE_SIZE
-
-
-async def test_stop_bumps_generation_and_clears(report, mock_bot, mock_ctx):
-    mock_ctx.guild = MagicMock()
-    mock_ctx.guild.id = 5
-    mock_ctx.voice_client = MagicMock()
-    mock_ctx.voice_client.is_playing.return_value = True
-    mock_ctx.voice_client.is_paused.return_value = False
-
-    cog = Music(mock_bot)
-    player = cog._player(5)
-    player.current = Track("Now", "https://youtu.be/n", 1, 1, "A")
-    player.queue.append(Track("Next", "https://youtu.be/x", 1, 1, "B"))
-    before = player.generation
-
-    await cog.stop.callback(cog, mock_ctx)
-
-    report.record("stop generation", before + 1, player.generation, section=SECTION_COMMANDS)
-    assert player.generation == before + 1
-    assert player.current is None
-    assert len(player.queue) == 0
-    mock_ctx.voice_client.stop.assert_called_once()
-
-
-async def test_play_next_aborts_stale_generation(report, mock_bot):
-    guild = MagicMock()
-    guild.id = 3
-    voice = MagicMock()
-    voice.is_connected.return_value = True
-    voice.is_playing.return_value = False
-    voice.is_paused.return_value = False
-    guild.voice_client = voice
-    mock_bot.get_guild.return_value = guild
-
-    cog = Music(mock_bot)
-    player = cog._player(3)
-    track = Track("Song", "https://www.youtube.com/watch?v=abc123xyz00", 10, 1, "A")
-    player.queue.append(track)
-
-    def slow_extract(_url):
-        # Simulate /stop during extract: bump generation before play starts.
-        player.generation += 1
-        return "https://cdn.example/stream"
-
-    with patch("cogs.music.extract_stream_url", side_effect=slow_extract):
-        with patch("cogs.music.discord.FFmpegOpusAudio") as ffmpeg:
-            await cog._play_next(3)
-
-    ffmpeg.assert_not_called()
-    voice.play.assert_not_called()
-    assert player.current is None
-    report.record("stale generation aborts play", True, True, section=SECTION_COMMANDS)
+    report.record("now playing", True, "Now playing" in actual, section=SECTION_COMMANDS)
+    assert "Now playing" in actual
 
 
 async def test_queue_empty_message(report, mock_bot, mock_ctx):
     mock_ctx.guild = MagicMock()
     mock_ctx.guild.id = 42
+    mock_ctx.voice_client = None
     cog = Music(mock_bot)
     await cog.queue.callback(cog, mock_ctx)
     actual = mock_ctx.send.call_args.args[0]
@@ -312,6 +166,7 @@ async def test_queue_empty_message(report, mock_bot, mock_ctx):
 async def test_np_when_idle(report, mock_bot, mock_ctx):
     mock_ctx.guild = MagicMock()
     mock_ctx.guild.id = 42
+    mock_ctx.voice_client = None
     cog = Music(mock_bot)
     await cog.now_playing.callback(cog, mock_ctx)
     actual = mock_ctx.send.call_args.args[0]
@@ -319,65 +174,16 @@ async def test_np_when_idle(report, mock_bot, mock_ctx):
     assert "Nothing is playing" in actual
 
 
-async def test_queue_lists_current_and_upcoming(report, mock_bot, mock_ctx):
+async def test_skip_when_idle(report, mock_bot, mock_ctx):
     mock_ctx.guild = MagicMock()
-    mock_ctx.guild.id = 7
+    mock_ctx.voice_client = None
     cog = Music(mock_bot)
-    player = cog._player(7)
-    player.current = Track(
-        title="Now Song",
-        webpage_url="https://youtu.be/now",
-        duration=120,
-        requester_id=1,
-        requester_name="Alice",
-    )
-    player.queue.append(
-        Track(
-            title="Next Song",
-            webpage_url="https://youtu.be/next",
-            duration=90,
-            requester_id=2,
-            requester_name="Bob",
-        )
-    )
-    await cog.queue.callback(cog, mock_ctx)
+    await cog.skip.callback(cog, mock_ctx)
     actual = mock_ctx.send.call_args.args[0]
-    report.record("queue contents", "Now Song + Next Song", actual, section=SECTION_COMMANDS)
-    assert "Now Song" in actual
-    assert "Next Song" in actual
-    assert "Bob" in actual
+    report.record("skip idle", "Nothing is playing", actual, section=SECTION_COMMANDS)
+    assert "Nothing is playing" in actual
 
 
-async def test_auto_leave_when_alone(report, mock_bot):
-    cog = Music(mock_bot)
-    mock_bot.user = MagicMock()
-    mock_bot.user.id = 999
-
-    channel = MagicMock()
-    channel.guild.id = 77
-    bot_member = MagicMock()
-    bot_member.bot = True
-    channel.members = [bot_member]
-
-    voice = AsyncMock()
-    voice.channel = channel
-    channel.guild.voice_client = voice
-
-    human = MagicMock()
-    human.id = 1
-    human.bot = False
-    before = MagicMock()
-    before.channel = channel
-    after = MagicMock()
-    after.channel = None
-
-    player = cog._player(77)
-    player.current = Track("X", "https://youtu.be/x", 1, 1, "A")
-    player.queue.append(Track("Y", "https://youtu.be/y", 1, 1, "B"))
-
-    await cog.on_voice_state_update(human, before, after)
-
-    voice.disconnect.assert_awaited()
-    assert player.current is None
-    assert len(player.queue) == 0
-    report.record("auto-leave when alone", True, True, section=SECTION_COMMANDS)
+def test_max_queue_size_constant(report):
+    report.record("MAX_QUEUE_SIZE", 50, MAX_QUEUE_SIZE, section=SECTION_COMMANDS)
+    assert MAX_QUEUE_SIZE == 50


### PR DESCRIPTION
## Summary
- Replace yt-dlp cookie/proxy playback with Lavalink (`discord-lavalink`) + youtube-source OAuth and Wavelink in the bot
- Slim the Dockerfile (drop Deno/FFmpeg) and update compose, env example, README, and music tests for the new stack
- VPS cookie secrets already cleaned; after merge, complete device OAuth once and save `YOUTUBE_OAUTH_REFRESH_TOKEN`

## Test plan
- [ ] CI green (pytest)
- [ ] After merge/deploy: `discord-lavalink` and `discord-bot` both healthy
- [ ] Complete YouTube device OAuth from Lavalink logs (throwaway Google account)
- [ ] `/play` URL and search work in a voice channel; skip/queue/leave still work