### PR TITLE
Switch /play from YouTube to SoundCloud

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,6 @@ DINK_MINT_AMOUNT=1
 # Messages per Grok request (falls back to per-message scoring if a batch response is bad)
 # SENTIMENT_BATCH_SIZE=10
 
-# Lavalink (YouTube /play). Compose sets LAVALINK_URI=http://lavalink:2333.
+# Lavalink (SoundCloud /play). Compose sets LAVALINK_URI=http://lavalink:2333.
 # Generate a long random password and use the same value for the Lavalink service.
 LAVALINK_PASSWORD=
-# After first OAuth (see README), paste the refresh token printed in discord-lavalink logs:
-# YOUTUBE_OAUTH_REFRESH_TOKEN=

--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ Successful `/1st` claims award **1 DINK** (configurable via `DINK_MINT_AMOUNT`).
 | `/pay` | Send DINK to another user |
 | `/request` | Ask another user for DINK (Accept / Decline) |
 
-### Music (YouTube voice)
+### Music (SoundCloud voice)
 
 Join a voice channel, then:
 
 | Command | Description |
 |---------|-------------|
-| `/play <url or search>` | Play a YouTube URL or the top search result |
+| `/play <url or search>` | Play a SoundCloud URL or the top search result |
 | `/skip` | Skip the current track |
 | `/stop` | Stop and clear the queue |
 | `/queue` | Show the queue |
@@ -99,24 +99,12 @@ Join a voice channel, then:
 | `/pause` / `/resume` | Pause or resume |
 | `/leave` | Disconnect from voice |
 
-Requires **Lavalink** (Java audio node) + the official YouTube plugin with OAuth. The Discord bot talks to Lavalink via Wavelink; it does **not** need yt-dlp, cookies, or a residential proxy for `/play`. The bot needs **Connect** and **Speak** permissions in the voice channel.
+Requires **Lavalink** (Java audio node) with SoundCloud enabled. The Discord bot talks to Lavalink via Wavelink. The bot needs **Connect** and **Speak** permissions in the voice channel.
 
 Production setup:
 
 1. Put a long random `LAVALINK_PASSWORD` in the VPS `.env` (compose passes it to both `lavalink` and `discord-bot`).
 2. Deploy: `cd /opt/apps/discordbot && ./deploy/deploy.sh` (starts `discord-lavalink` + `discord-bot`).
-3. Complete **YouTube OAuth once** with a **throwaway Google account** (never your main account):
-
-```bash
-# Watch for the device login URL/code:
-ssh dinkboard 'docker logs -f discord-lavalink' | grep -iE 'oauth|device|https://www.youtube.com'
-
-# Open the URL, enter the code, authorize the spare account.
-# Lavalink prints a refresh token — save it:
-#   YOUTUBE_OAUTH_REFRESH_TOKEN=...
-# in /opt/apps/discordbot/.env, then:
-ssh dinkboard 'cd /opt/apps/discordbot && docker compose -f docker-compose.prod.yml up -d lavalink'
-```
 
 Locally: run Lavalink (same `deploy/lavalink/application.yml`), set `LAVALINK_URI=http://127.0.0.1:2333` and `LAVALINK_PASSWORD`, then start the bot.
 
@@ -130,7 +118,7 @@ Setup: DinkCoin tables are created with the shared Postgres schema (`deploy/post
   - `ai.py`: AI-related commands including ChatGPT integration and DALL·E 3 image generation.
   - `first.py`: Commands for tracking and managing first messages of the day.
   - `dinkcoin.py`: DinkCoin balance, ledger, and peer-to-peer transfers.
-  - `music.py`: YouTube voice playback (`/play` URL or search) via Lavalink + Wavelink.
+  - `music.py`: SoundCloud voice playback (`/play` URL or search) via Lavalink + Wavelink.
   - `misc.py`: Miscellaneous utility commands.
   - `server.py`: Server management and dashboard-related commands.
   - `utility.py`: General utility commands.
@@ -139,7 +127,7 @@ Setup: DinkCoin tables are created with the shared Postgres schema (`deploy/post
   - `db.py`: Database operations for logging messages and events.
 - `scripts/dinkcoin_schema.sql`: Postgres tables for the DINK ledger.
 - `Dockerfile` / `docker-compose.prod.yml`: VPS containers for the bot + Lavalink (joins the dinkboard Docker network).
-- `deploy/lavalink/application.yml`: Lavalink + youtube-source OAuth config.
+- `deploy/lavalink/application.yml`: Lavalink config (SoundCloud enabled; YouTube off).
 - `requirements.txt`: Python dependencies required for the project.
 - `requirements-dev.txt`: Test dependencies (pytest, pytest-asyncio).
 - `tests/`: Pytest suite (mocked command tests, unit tests, and live smoke tests).

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -1,4 +1,4 @@
-"""YouTube voice playback via Lavalink + Wavelink (URL or search query)."""
+"""SoundCloud voice playback via Lavalink + Wavelink (URL or search query)."""
 
 from __future__ import annotations
 
@@ -20,47 +20,40 @@ logger = logging.getLogger(__name__)
 
 MAX_QUEUE_SIZE = 50
 
-YOUTUBE_HOSTS = frozenset({
-    "youtube.com",
-    "www.youtube.com",
-    "m.youtube.com",
-    "music.youtube.com",
-    "youtu.be",
-    "www.youtu.be",
+SOUNDCLOUD_HOSTS = frozenset({
+    "soundcloud.com",
+    "www.soundcloud.com",
+    "m.soundcloud.com",
+    "on.soundcloud.com",
 })
 
-_YOUTUBE_HOST_RE = re.compile(
-    r"^(?:https?://)?(?:www\.)?(?:music\.)?(?:m\.)?(?:youtube\.com|youtu\.be)/",
+_SOUNDCLOUD_HOST_RE = re.compile(
+    r"^(?:https?://)?(?:www\.|m\.|on\.)?soundcloud\.com/",
     re.IGNORECASE,
 )
 
 
-def is_youtube_url(query: str) -> bool:
-    """True only when the entire query is a YouTube URL (not search text)."""
+def is_soundcloud_url(query: str) -> bool:
+    """True only when the entire query is a SoundCloud URL (not search text)."""
     text = query.strip()
     if not text or any(ch.isspace() for ch in text):
         return False
-    if not _YOUTUBE_HOST_RE.match(text):
+    if not _SOUNDCLOUD_HOST_RE.match(text):
         return False
     try:
         parsed = urlparse(text if "://" in text else f"https://{text}")
     except ValueError:
         return False
     host = (parsed.hostname or "").lower()
-    if host not in YOUTUBE_HOSTS:
+    if host not in SOUNDCLOUD_HOSTS:
         return False
-    if host.endswith("youtu.be"):
-        return bool(parsed.path.strip("/"))
-    path = parsed.path or ""
-    return bool(parsed.query) or path.startswith(
-        ("/watch", "/shorts/", "/live/", "/embed/", "/v/")
-    )
+    return bool(parsed.path.strip("/"))
 
 
 def to_search_query(query: str) -> str:
-    """Normalize user input for Wavelink search (URL or bare search text)."""
+    """Normalize user input for Wavelink SoundCloud search (URL or bare search text)."""
     text = query.strip()
-    if is_youtube_url(text):
+    if is_soundcloud_url(text):
         if "://" not in text:
             return f"https://{text}"
         return text
@@ -87,7 +80,6 @@ def _track_duration_seconds(track: wavelink.Playable) -> Optional[int]:
     length = getattr(track, "length", None)
     if length is None:
         return None
-    # Wavelink lengths are milliseconds.
     try:
         return max(0, int(length) // 1000)
     except (TypeError, ValueError):
@@ -96,29 +88,25 @@ def _track_duration_seconds(track: wavelink.Playable) -> Optional[int]:
 
 def _track_url(track: wavelink.Playable) -> str:
     uri = getattr(track, "uri", None)
-    if uri and is_youtube_url(str(uri)):
-        return str(uri) if "://" in str(uri) else f"https://{uri}"
-    identifier = getattr(track, "identifier", None)
-    if identifier and re.fullmatch(r"[\w-]{6,}", str(identifier)):
-        return f"https://www.youtube.com/watch?v={identifier}"
-    return str(uri or "https://www.youtube.com")
+    if uri:
+        text = str(uri)
+        if "://" not in text and is_soundcloud_url(text):
+            return f"https://{text}"
+        return text
+    return "https://soundcloud.com"
 
 
 def _lavalink_user_message(exc: BaseException) -> str:
     text = str(exc).lower()
-    if "oauth" in text or "login" in text or "sign in" in text or "not a bot" in text:
-        return (
-            "YouTube needs Lavalink OAuth. An admin should check "
-            "`discord-lavalink` logs for the device login URL, then set "
-            "`YOUTUBE_OAUTH_REFRESH_TOKEN`."
-        )
-    if "nodisconnected" in text.replace(" ", "") or "no nodes" in text or "node" in text and "connect" in text:
+    if "nodisconnected" in text.replace(" ", "") or "no nodes" in text or (
+        "node" in text and "connect" in text
+    ):
         return "Music backend is offline. Try again in a moment."
-    return "Couldn't find that on YouTube. Try a different search or paste a video URL."
+    return "Couldn't find that on SoundCloud. Try a different search or paste a track URL."
 
 
 class Music(commands.Cog):
-    """Play YouTube audio in a voice channel via Lavalink (URL or search)."""
+    """Play SoundCloud audio in a voice channel via Lavalink (URL or search)."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
@@ -142,6 +130,25 @@ class Music(commands.Cog):
             await wavelink.Pool.close()
         except Exception:
             logger.debug("Lavalink pool close failed", exc_info=True)
+
+    @commands.Cog.listener()
+    async def on_wavelink_track_exception(
+        self, payload: wavelink.TrackExceptionEventPayload
+    ) -> None:
+        """Surface stream failures instead of silent 'playing'."""
+        exc = payload.exception or {}
+        message = str(exc.get("message") or exc.get("cause") or exc)
+        logger.error("Track exception for %r: %s", getattr(payload.track, "title", None), message)
+        player = payload.player
+        text_channel = getattr(player, "music_text_channel", None) if player is not None else None
+        if text_channel is None:
+            return
+        try:
+            await text_channel.send(
+                "Couldn't play that track. Try another SoundCloud search or URL."
+            )
+        except discord.HTTPException:
+            logger.debug("Failed to notify channel of track exception", exc_info=True)
 
     def _track_line(self, track: wavelink.Playable, requester: str, *, prefix: str = "") -> str:
         title = safe_title(getattr(track, "title", None) or "Unknown title")
@@ -183,21 +190,22 @@ class Music(commands.Cog):
             raise commands.CommandError(f"Could not join voice: {exc}") from exc
 
         assert isinstance(player, wavelink.Player)
-        # Advance the queue when a track ends (no AutoPlay recommendations).
         player.autoplay = wavelink.AutoPlayMode.partial
+        if ctx.channel is not None:
+            player.music_text_channel = ctx.channel  # type: ignore[attr-defined]
         return player
 
-    @commands.hybrid_command(brief="Play a YouTube URL or search query in voice")
-    @app_commands.describe(query="YouTube URL or search text (e.g. tubthumping)")
+    @commands.hybrid_command(brief="Play a SoundCloud URL or search query in voice")
+    @app_commands.describe(query="SoundCloud URL or search text (e.g. lofi hip hop)")
     async def play(self, ctx: commands.Context, *, query: str):
-        """Play audio from a YouTube URL or the top search result."""
+        """Play audio from a SoundCloud URL or the top search result."""
         if ctx.guild is None:
             await ctx.send("This command only works in a server.")
             return
 
         query = query.strip()
         if not query:
-            await ctx.send("Give me a YouTube URL or something to search for.")
+            await ctx.send("Give me a SoundCloud URL or something to search for.")
             return
 
         async with acknowledge(ctx):
@@ -210,16 +218,16 @@ class Music(commands.Cog):
             try:
                 tracks = await wavelink.Playable.search(
                     to_search_query(query),
-                    source=wavelink.TrackSource.YouTube,
+                    source=wavelink.TrackSource.SoundCloud,
                 )
             except Exception as exc:
-                logger.exception("Lavalink search failed for query %r", query)
+                logger.exception("Lavalink SoundCloud search failed for query %r", query)
                 await ctx.send(_lavalink_user_message(exc))
                 return
 
             if not tracks:
                 await ctx.send(
-                    "Couldn't find that on YouTube. Try a different search or paste a video URL."
+                    "Couldn't find that on SoundCloud. Try a different search or paste a track URL."
                 )
                 return
 

--- a/deploy/lavalink/application.yml
+++ b/deploy/lavalink/application.yml
@@ -3,13 +3,11 @@ server:
   address: 0.0.0.0
 
 lavalink:
-  plugins:
-    - dependency: "dev.lavalink.youtube:youtube-plugin:1.18.2"
-      snapshot: false
   server:
     # Set LAVALINK_PASSWORD in the VPS .env (shared with the bot).
     password: "${LAVALINK_PASSWORD}"
     sources:
+      # YouTube disabled — datacenter IPs are blocked even with OAuth.
       youtube: false
       bandcamp: true
       soundcloud: true
@@ -23,29 +21,9 @@ lavalink:
     resamplingQuality: LOW
     trackStuckThresholdMs: 10000
     useSeekGhosting: true
-    youtubePlaylistLoadLimit: 6
     playerUpdateInterval: 5
-    youtubeSearchEnabled: true
     soundcloudSearchEnabled: true
     gc-warnings: true
-
-plugins:
-  youtube:
-    enabled: true
-    allowSearch: true
-    allowDirectVideoIds: true
-    allowDirectPlaylistIds: true
-    clients:
-      - MUSIC
-      - WEB
-      - WEBEMBEDDED
-      - ANDROID_VR
-      - TV
-    oauth:
-      # Device OAuth on first boot (check lavalink logs for the URL/code).
-      # Then put the printed refresh token in YOUTUBE_OAUTH_REFRESH_TOKEN.
-      enabled: true
-      refreshToken: "${YOUTUBE_OAUTH_REFRESH_TOKEN:}"
 
 metrics:
   prometheus:
@@ -60,7 +38,6 @@ logging:
   level:
     root: INFO
     lavalink: INFO
-    "dev.lavalink.youtube.http.YoutubeOauth2Handler": INFO
   request:
     enabled: true
     includeClientInfo: true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,8 +4,6 @@
 #
 # Required in .env (never commit):
 #   LAVALINK_PASSWORD=...
-# Optional after first YouTube OAuth (see README):
-#   YOUTUBE_OAUTH_REFRESH_TOKEN=...
 
 services:
   lavalink:
@@ -14,7 +12,6 @@ services:
     restart: unless-stopped
     environment:
       LAVALINK_PASSWORD: ${LAVALINK_PASSWORD}
-      YOUTUBE_OAUTH_REFRESH_TOKEN: ${YOUTUBE_OAUTH_REFRESH_TOKEN:-}
     volumes:
       - ./deploy/lavalink/application.yml:/opt/Lavalink/application.yml:ro
     networks:

--- a/docs/self_knowledge/music.md
+++ b/docs/self_knowledge/music.md
@@ -1,15 +1,15 @@
 # Music — `/play`
 
-Play YouTube audio in a voice channel. Join a voice channel first, then use
-`/play` with either a **YouTube URL** or a **search phrase**.
+Play SoundCloud audio in a voice channel. Join a voice channel first, then use
+`/play` with either a **SoundCloud URL** or a **search phrase**.
 
-Audio is fetched by **Lavalink** (YouTube plugin + OAuth), not by the Discord
-bot process itself.
+Audio is fetched by **Lavalink** (built-in SoundCloud source), not by the Discord
+bot process itself. YouTube is not supported (VPS IPs get blocked).
 
 ## Play — `/play`
 
-- `/play https://youtu.be/...` — play that video's audio
-- `/play tubthumping` — search YouTube and play the top result
+- `/play https://soundcloud.com/...` — play that track
+- `/play lofi hip hop` — search SoundCloud and play the top result
 - If something is already playing, new requests are **queued**
 
 Also works with the `_play` prefix.
@@ -29,6 +29,6 @@ Also works with the `_play` prefix.
 ## Tips for members
 
 - You must be in a voice channel before `/play`.
-- Search uses YouTube's top match — if it's wrong, paste the exact URL instead.
+- Search uses SoundCloud's top match — if it's wrong, paste the exact URL instead.
 - `/voice` is different: that one answers a prompt as an MP3 file in chat, not
   voice-channel music.

--- a/docs/self_knowledge/overview.md
+++ b/docs/self_knowledge/overview.md
@@ -14,7 +14,7 @@ older `_` prefix still works. Commands are case-insensitive.
 - **Chat & creativity** — `/ask` for questions and conversation (including images
   you attach), `/imagine` for AI art, `/voice` for a spoken reply, and `/clear`
   to start a fresh chat. See the `ai_features` topic.
-- **Music** — `/play` streams YouTube audio in a voice channel from a URL or
+- **Music** — `/play` streams SoundCloud audio in a voice channel from a URL or
   search text, with `/skip`, `/queue`, `/np`, `/pause`, `/resume`, `/stop`, and
   `/leave`. See the `music` topic.
 - **Server stats** — you keep track of activity on the server and post a monthly

--- a/tests/test_music_commands.py
+++ b/tests/test_music_commands.py
@@ -1,8 +1,7 @@
-"""Unit tests for music helpers and command edge cases (Lavalink/Wavelink)."""
+"""Unit tests for music helpers and command edge cases (Lavalink/Wavelink SoundCloud)."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 import wavelink
 
 from cogs.music import (
@@ -10,36 +9,37 @@ from cogs.music import (
     Music,
     _lavalink_user_message,
     format_duration,
-    is_youtube_url,
+    is_soundcloud_url,
     safe_title,
     to_search_query,
 )
 from tests.reporting import SECTION_COMMANDS
 
 
-def test_is_youtube_url_accepts_common_forms(report):
+def test_is_soundcloud_url_accepts_common_forms(report):
     cases = [
-        ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", True),
-        ("https://youtu.be/dQw4w9WgXcQ", True),
-        ("youtube.com/watch?v=dQw4w9WgXcQ", True),
-        ("https://music.youtube.com/watch?v=dQw4w9WgXcQ", True),
-        ("https://www.youtube.com/shorts/abc123xyz00", True),
+        ("https://soundcloud.com/artist/track-name", True),
+        ("https://www.soundcloud.com/artist/track-name", True),
+        ("https://m.soundcloud.com/artist/track-name", True),
+        ("https://on.soundcloud.com/abc123", True),
+        ("soundcloud.com/artist/track-name", True),
         ("not a url", False),
-        ("https://example.com/watch?v=dQw4w9WgXcQ", False),
-        ("https://youtube.com/", False),
-        ("tubthumping", False),
-        ("youtube.com/watch?v=dQw4w9WgXcQ and more", False),
+        ("https://example.com/track", False),
+        ("https://soundcloud.com/", False),
+        ("lofi hip hop", False),
+        ("soundcloud.com/artist/track and more", False),
+        ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", False),
     ]
     for value, expected in cases:
-        actual = is_youtube_url(value)
-        report.record(f"is_youtube_url({value!r})", expected, actual, section=SECTION_COMMANDS)
+        actual = is_soundcloud_url(value)
+        report.record(f"is_soundcloud_url({value!r})", expected, actual, section=SECTION_COMMANDS)
         assert actual is expected
 
 
 def test_to_search_query(report):
-    assert to_search_query("tubthumping") == "tubthumping"
-    report.record("search text", "tubthumping", to_search_query("tubthumping"), section=SECTION_COMMANDS)
-    bare = to_search_query("youtube.com/watch?v=dQw4w9WgXcQ")
+    assert to_search_query("lofi hip hop") == "lofi hip hop"
+    report.record("search text", "lofi hip hop", to_search_query("lofi hip hop"), section=SECTION_COMMANDS)
+    bare = to_search_query("soundcloud.com/artist/track-name")
     report.record("bare url gets scheme", True, bare.startswith("https://"), section=SECTION_COMMANDS)
     assert bare.startswith("https://")
 
@@ -57,16 +57,17 @@ def test_safe_title(report):
     assert "[" not in actual and "]" not in actual
 
 
-def test_lavalink_user_message_oauth(report):
-    msg = _lavalink_user_message(Exception("This video requires login / OAuth"))
-    report.record("oauth message", "OAuth", msg, section=SECTION_COMMANDS)
-    assert "oauth" in msg.lower()
+def test_lavalink_user_message_offline(report):
+    msg = _lavalink_user_message(Exception("No nodes currently available / node connect failed"))
+    report.record("offline message", "backend is offline", msg, section=SECTION_COMMANDS)
+    assert "offline" in msg.lower()
 
 
 def test_lavalink_user_message_generic(report):
     msg = _lavalink_user_message(Exception("something else"))
     report.record("generic message", "Couldn't find", msg, section=SECTION_COMMANDS)
     assert "couldn't find" in msg.lower()
+    assert "soundcloud" in msg.lower()
 
 
 async def test_play_requires_voice_channel(report, mock_bot, mock_ctx):
@@ -77,7 +78,7 @@ async def test_play_requires_voice_channel(report, mock_bot, mock_ctx):
     mock_ctx.voice_client = None
 
     cog = Music(mock_bot)
-    await cog.play.callback(cog, mock_ctx, query="tubthumping")
+    await cog.play.callback(cog, mock_ctx, query="lofi")
     actual = mock_ctx.send.call_args.args[0]
     report.record("play without voice", "Join a voice channel", actual, section=SECTION_COMMANDS)
     assert "Join a voice channel" in actual
@@ -103,13 +104,15 @@ async def test_play_queues_when_busy(report, mock_bot, mock_ctx):
     track = MagicMock()
     track.title = "Song"
     track.length = 120000
-    track.uri = "https://www.youtube.com/watch?v=abc123xyz00"
-    track.identifier = "abc123xyz00"
+    track.uri = "https://soundcloud.com/artist/song"
+    track.identifier = "123"
 
     cog = Music(mock_bot)
     with patch.object(cog, "_ensure_player", AsyncMock(return_value=player)):
-        with patch("cogs.music.wavelink.Playable.search", AsyncMock(return_value=[track])):
-            await cog.play.callback(cog, mock_ctx, query="tubthumping")
+        with patch("cogs.music.wavelink.Playable.search", AsyncMock(return_value=[track])) as search:
+            await cog.play.callback(cog, mock_ctx, query="lofi")
+            search.assert_awaited()
+            assert search.await_args.kwargs.get("source") == wavelink.TrackSource.SoundCloud
 
     player.queue.put_wait.assert_awaited_once_with(track)
     player.play.assert_not_called()
@@ -136,15 +139,15 @@ async def test_play_starts_when_idle(report, mock_bot, mock_ctx):
     mock_ctx.voice_client = player
 
     track = MagicMock()
-    track.title = "Tubthumping"
+    track.title = "Lofi Beat"
     track.length = 213000
-    track.uri = "https://www.youtube.com/watch?v=2H5uWRjFsGc"
-    track.identifier = "2H5uWRjFsGc"
+    track.uri = "https://soundcloud.com/artist/lofi-beat"
+    track.identifier = "456"
 
     cog = Music(mock_bot)
     with patch.object(cog, "_ensure_player", AsyncMock(return_value=player)):
         with patch("cogs.music.wavelink.Playable.search", AsyncMock(return_value=[track])):
-            await cog.play.callback(cog, mock_ctx, query="tubthumping")
+            await cog.play.callback(cog, mock_ctx, query="lofi")
 
     player.play.assert_awaited_once_with(track)
     actual = mock_ctx.send.call_args.args[0]

--- a/utils/self_knowledge.py
+++ b/utils/self_knowledge.py
@@ -21,7 +21,7 @@ TOPICS = {
     "first_game": "Rules of the daily /1st game: claiming, score, streaks, and juice",
     "dinkcoin": "How DINK works: earning it, spending it, and the leaderboard",
     "ai_features": "How /ask, /imagine, /voice, and /clear work for members",
-    "music": "How /play works: YouTube URLs, search, queue, and voice controls",
+    "music": "How /play works: SoundCloud URLs, search, queue, and voice controls",
     "server_stats": "Activity tracking, the monthly report, and the public dashboard",
 }
 


### PR DESCRIPTION
## Summary
- Point `/play` at SoundCloud (URL or `scsearch`) via Wavelink instead of YouTube
- Drop the youtube-source plugin / OAuth from Lavalink config and compose
- Update docs and tests for the SoundCloud-only music path

## Test plan
- [ ] CI green
- [ ] After deploy: `/play lofi` joins voice and produces audio
- [ ] SoundCloud URL `/play` works; queue/skip/leave still work
- [ ] VPS `.env` no longer needs `YOUTUBE_OAUTH_REFRESH_TOKEN`