### PR TITLE
Skip SoundCloud Go+ previews and hide link embeds

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -86,6 +86,27 @@ def _track_duration_seconds(track: wavelink.Playable) -> Optional[int]:
         return None
 
 
+def is_preview_track(track: wavelink.Playable) -> bool:
+    """True when SoundCloud only exposes a short Go+ preview stream (~30s)."""
+    for attr in ("identifier", "uri"):
+        value = getattr(track, attr, None)
+        if value and "/preview/" in str(value).lower():
+            return True
+    return False
+
+
+def pick_playable_track(tracks) -> Optional[wavelink.Playable]:
+    """Prefer a full stream over a SoundCloud preview clip."""
+    if isinstance(tracks, wavelink.Playlist):
+        candidates = list(tracks.tracks)
+    else:
+        candidates = list(tracks)
+    for track in candidates:
+        if not is_preview_track(track):
+            return track
+    return candidates[0] if candidates else None
+
+
 def _track_url(track: wavelink.Playable) -> str:
     uri = getattr(track, "uri", None)
     if uri:
@@ -153,9 +174,10 @@ class Music(commands.Cog):
     def _track_line(self, track: wavelink.Playable, requester: str, *, prefix: str = "") -> str:
         title = safe_title(getattr(track, "title", None) or "Unknown title")
         duration = format_duration(_track_duration_seconds(track))
+        # Angle brackets keep the link clickable but suppress Discord's rich embed.
         return (
             f"{prefix}**{title}** ({duration})\n"
-            f"{_track_url(track)} — {requester}"
+            f"<{_track_url(track)}> — {requester}"
         )
 
     async def _ensure_player(self, ctx: commands.Context) -> wavelink.Player:
@@ -231,8 +253,21 @@ class Music(commands.Cog):
                 )
                 return
 
-            track = tracks[0] if not isinstance(tracks, wavelink.Playlist) else tracks.tracks[0]
+            track = pick_playable_track(tracks)
+            if track is None:
+                await ctx.send(
+                    "Couldn't find that on SoundCloud. Try a different search or paste a track URL."
+                )
+                return
+
             requester = ctx.author.display_name
+            preview_note = ""
+            if is_preview_track(track):
+                # Direct URL (or all search hits) may still be preview-only.
+                preview_note = (
+                    "\n⚠️ SoundCloud only allows a short preview of this track "
+                    "(full stream needs Go+). Try another upload or search."
+                )
 
             if player.current is not None or len(player.queue) > 0:
                 if len(player.queue) >= MAX_QUEUE_SIZE:
@@ -246,11 +281,15 @@ class Music(commands.Cog):
                         requester,
                         prefix=f"Queued **#{position}:** ",
                     )
+                    + preview_note
                 )
                 return
 
             await player.play(track)
-            await ctx.send(self._track_line(track, requester, prefix="▶️ **Now playing:** "))
+            await ctx.send(
+                self._track_line(track, requester, prefix="▶️ **Now playing:** ")
+                + preview_note
+            )
 
     @commands.hybrid_command(brief="Skip the current track")
     async def skip(self, ctx: commands.Context):

--- a/deploy/lavalink/application.yml
+++ b/deploy/lavalink/application.yml
@@ -23,6 +23,8 @@ lavalink:
     useSeekGhosting: true
     playerUpdateInterval: 5
     soundcloudSearchEnabled: true
+    # Skip ~30s Go+ preview streams so /play doesn't cut songs short.
+    soundcloudFilterOutPreviewTracks: true
     gc-warnings: true
 
 metrics:

--- a/docs/self_knowledge/music.md
+++ b/docs/self_knowledge/music.md
@@ -30,5 +30,8 @@ Also works with the `_play` prefix.
 
 - You must be in a voice channel before `/play`.
 - Search uses SoundCloud's top match — if it's wrong, paste the exact URL instead.
+- Some official uploads are **preview-only** on SoundCloud (~30 seconds). The bot
+  skips those in search when a full stream exists; if a pasted URL is preview-only,
+  it will warn you. Try a different upload of the same song.
 - `/voice` is different: that one answers a prompt as an MP3 file in chat, not
   voice-channel music.

--- a/tests/test_music_commands.py
+++ b/tests/test_music_commands.py
@@ -9,7 +9,9 @@ from cogs.music import (
     Music,
     _lavalink_user_message,
     format_duration,
+    is_preview_track,
     is_soundcloud_url,
+    pick_playable_track,
     safe_title,
     to_search_query,
 )
@@ -55,6 +57,35 @@ def test_safe_title(report):
     actual = safe_title("Song [Live] *wow*")
     report.record("safe_title strips brackets", True, "[" not in actual and "]" not in actual, section=SECTION_COMMANDS)
     assert "[" not in actual and "]" not in actual
+
+
+def test_is_preview_track(report):
+    preview = MagicMock()
+    preview.identifier = (
+        "https://api-v2.soundcloud.com/media/soundcloud:tracks:1/abc/preview/hls"
+    )
+    preview.uri = "https://soundcloud.com/artist/song"
+    full = MagicMock()
+    full.identifier = (
+        "https://api-v2.soundcloud.com/media/soundcloud:tracks:1/abc/stream/hls"
+    )
+    full.uri = "https://soundcloud.com/artist/song"
+    report.record("preview detected", True, is_preview_track(preview), section=SECTION_COMMANDS)
+    report.record("full stream not preview", False, is_preview_track(full), section=SECTION_COMMANDS)
+    assert is_preview_track(preview) is True
+    assert is_preview_track(full) is False
+
+
+def test_pick_playable_track_skips_preview(report):
+    preview = MagicMock()
+    preview.identifier = "https://api-v2.soundcloud.com/media/x/preview/hls"
+    preview.uri = "https://soundcloud.com/a/preview-song"
+    full = MagicMock()
+    full.identifier = "https://api-v2.soundcloud.com/media/x/stream/hls"
+    full.uri = "https://soundcloud.com/a/full-song"
+    chosen = pick_playable_track([preview, full])
+    report.record("picks full over preview", full, chosen, section=SECTION_COMMANDS)
+    assert chosen is full
 
 
 def test_lavalink_user_message_offline(report):
@@ -105,7 +136,7 @@ async def test_play_queues_when_busy(report, mock_bot, mock_ctx):
     track.title = "Song"
     track.length = 120000
     track.uri = "https://soundcloud.com/artist/song"
-    track.identifier = "123"
+    track.identifier = "https://api-v2.soundcloud.com/media/x/stream/hls"
 
     cog = Music(mock_bot)
     with patch.object(cog, "_ensure_player", AsyncMock(return_value=player)):
@@ -142,7 +173,7 @@ async def test_play_starts_when_idle(report, mock_bot, mock_ctx):
     track.title = "Lofi Beat"
     track.length = 213000
     track.uri = "https://soundcloud.com/artist/lofi-beat"
-    track.identifier = "456"
+    track.identifier = "https://api-v2.soundcloud.com/media/x/stream/hls"
 
     cog = Music(mock_bot)
     with patch.object(cog, "_ensure_player", AsyncMock(return_value=player)):
@@ -153,6 +184,85 @@ async def test_play_starts_when_idle(report, mock_bot, mock_ctx):
     actual = mock_ctx.send.call_args.args[0]
     report.record("now playing", True, "Now playing" in actual, section=SECTION_COMMANDS)
     assert "Now playing" in actual
+    assert "<https://soundcloud.com/artist/lofi-beat>" in actual
+    report.record("url wrapped to hide embed", True, True, section=SECTION_COMMANDS)
+
+
+async def test_play_skips_preview_for_full_stream(report, mock_bot, mock_ctx):
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 4
+    mock_ctx.guild.me = None
+    mock_ctx.author.voice = MagicMock()
+    mock_ctx.author.display_name = "Alex"
+
+    player = MagicMock(spec=wavelink.Player)
+    player.playing = False
+    player.paused = False
+    player.current = None
+    player.queue = MagicMock()
+    player.queue.__bool__ = MagicMock(return_value=False)
+    player.queue.__len__ = MagicMock(return_value=0)
+    player.play = AsyncMock()
+    mock_ctx.voice_client = player
+
+    preview = MagicMock()
+    preview.title = "Official Preview"
+    preview.length = 180000
+    preview.uri = "https://soundcloud.com/label/official"
+    preview.identifier = "https://api-v2.soundcloud.com/media/x/preview/hls"
+    full = MagicMock()
+    full.title = "Fan Upload Full"
+    full.length = 180000
+    full.uri = "https://soundcloud.com/fan/full"
+    full.identifier = "https://api-v2.soundcloud.com/media/y/stream/hls"
+
+    cog = Music(mock_bot)
+    with patch.object(cog, "_ensure_player", AsyncMock(return_value=player)):
+        with patch(
+            "cogs.music.wavelink.Playable.search",
+            AsyncMock(return_value=[preview, full]),
+        ):
+            await cog.play.callback(cog, mock_ctx, query="tubthumping")
+
+    player.play.assert_awaited_once_with(full)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("skipped preview hit", True, "Fan Upload Full" in actual, section=SECTION_COMMANDS)
+    assert "Fan Upload Full" in actual
+    assert "preview" not in actual.lower()
+
+
+async def test_play_warns_when_only_preview(report, mock_bot, mock_ctx):
+    mock_ctx.guild = MagicMock()
+    mock_ctx.guild.id = 5
+    mock_ctx.guild.me = None
+    mock_ctx.author.voice = MagicMock()
+    mock_ctx.author.display_name = "Alex"
+
+    player = MagicMock(spec=wavelink.Player)
+    player.playing = False
+    player.paused = False
+    player.current = None
+    player.queue = MagicMock()
+    player.queue.__bool__ = MagicMock(return_value=False)
+    player.queue.__len__ = MagicMock(return_value=0)
+    player.play = AsyncMock()
+    mock_ctx.voice_client = player
+
+    preview = MagicMock()
+    preview.title = "Safety Dance"
+    preview.length = 30000
+    preview.uri = "https://soundcloud.com/men-without-hats/safety-dance-1"
+    preview.identifier = "https://api-v2.soundcloud.com/media/x/preview/hls"
+
+    cog = Music(mock_bot)
+    with patch.object(cog, "_ensure_player", AsyncMock(return_value=player)):
+        with patch("cogs.music.wavelink.Playable.search", AsyncMock(return_value=[preview])):
+            await cog.play.callback(cog, mock_ctx, query="safety dance")
+
+    player.play.assert_awaited_once_with(preview)
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("preview warning", True, "preview" in actual.lower(), section=SECTION_COMMANDS)
+    assert "preview" in actual.lower()
 
 
 async def test_queue_empty_message(report, mock_bot, mock_ctx):


### PR DESCRIPTION
## Summary
- Filter SoundCloud Go+ `preview/hls` streams in Lavalink and prefer full `stream/hls` results in `/play`, with a warning when only a preview is available
- Wrap track URLs in `<>` so Discord does not show rich embeds on now-playing / queue messages

## Test plan
- [ ] `/play tubthumping` (or similar official hit) picks a full-stream upload when one exists
- [ ] Preview-only pasted URL still plays but shows the Go+ warning
- [ ] Now-playing message shows a clickable SoundCloud link with no embed card
- [ ] CI unit tests for music helpers pass