### PR TITLE
Fix VPS deploy SSH step and recreate Lavalink on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,9 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
-          script_stop: true
+          # Remote default shell may be dash; invoke bash so set -o pipefail works.
+          # script_stop was removed from ssh-action — use set -e in the script instead.
           script: |
+            #!/usr/bin/env bash
             set -euo pipefail
             /opt/apps/discordbot/deploy/deploy.sh

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -15,7 +15,8 @@ if [[ ! -f .env ]]; then
 fi
 
 echo "==> Building and starting discord-bot"
-docker compose -f docker-compose.prod.yml up --build -d
+# Force-recreate so bind-mounted Lavalink config (application.yml) is picked up.
+docker compose -f docker-compose.prod.yml up --build -d --force-recreate
 
 echo "==> Container status"
 docker compose -f docker-compose.prod.yml ps


### PR DESCRIPTION
## Summary
- Remove deprecated `script_stop` from `appleboy/ssh-action` (was warning as unexpected input)
- Run the remote deploy script under bash (`#!/usr/bin/env bash`) so `set -o pipefail` does not fail under dash
- Force-recreate compose services on deploy so Lavalink picks up mounted `application.yml` changes

## Test plan
- [x] Manual VPS deploy already applied `#43` (`c7fbfd9`) and restarted Lavalink + bot
- [ ] CI passes
- [ ] After merge, Deploy workflow succeeds and VPS lands on this commit
