### PR TITLE
Only play fully streamable SoundCloud uploads

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -19,7 +19,7 @@ from utils.interactions import acknowledge
 logger = logging.getLogger(__name__)
 
 MAX_QUEUE_SIZE = 50
-MAX_PLAY_CANDIDATES = 5
+MAX_PLAY_CANDIDATES = 8
 
 SOUNDCLOUD_HOSTS = frozenset({
     "soundcloud.com",
@@ -96,30 +96,19 @@ def is_preview_track(track: wavelink.Playable) -> bool:
     return False
 
 
-def rank_playable_tracks(tracks) -> list[wavelink.Playable]:
-    """Order candidates: full streams first, then previews (search order preserved)."""
+def full_stream_tracks(tracks) -> list[wavelink.Playable]:
+    """Return only fully streamable uploads (no Go+ preview clips)."""
     if isinstance(tracks, wavelink.Playlist):
         candidates = list(tracks.tracks)
     else:
         candidates = list(tracks)
-    full = [t for t in candidates if not is_preview_track(t)]
-    previews = [t for t in candidates if is_preview_track(t)]
-    return full + previews
+    return [t for t in candidates if not is_preview_track(t)]
 
 
 def pick_playable_track(tracks) -> Optional[wavelink.Playable]:
-    """Prefer a full stream over a SoundCloud preview clip."""
-    ranked = rank_playable_tracks(tracks)
-    return ranked[0] if ranked else None
-
-
-def _preview_note(track: wavelink.Playable) -> str:
-    if not is_preview_track(track):
-        return ""
-    return (
-        "\n⚠️ SoundCloud only allows a short preview of this track "
-        "(full stream needs Go+)."
-    )
+    """First fully streamable SoundCloud result, if any."""
+    full = full_stream_tracks(tracks)
+    return full[0] if full else None
 
 
 def _track_url(track: wavelink.Playable) -> str:
@@ -187,6 +176,8 @@ class Music(commands.Cog):
 
         while fallbacks:
             next_track = fallbacks.pop(0)
+            if is_preview_track(next_track):
+                continue
             player.music_fallbacks = fallbacks  # type: ignore[attr-defined]
             try:
                 await player.play(next_track)
@@ -197,7 +188,6 @@ class Music(commands.Cog):
                 )
                 continue
             if text_channel is not None:
-                note = _preview_note(next_track)
                 try:
                     await text_channel.send(
                         self._track_line(
@@ -205,7 +195,6 @@ class Music(commands.Cog):
                             requester,
                             prefix="▶️ **Playing instead:** ",
                         )
-                        + note
                     )
                 except discord.HTTPException:
                     logger.debug("Failed to notify channel of fallback play", exc_info=True)
@@ -216,7 +205,7 @@ class Music(commands.Cog):
             return
         try:
             await text_channel.send(
-                "Couldn't play that track. Try another SoundCloud search or URL."
+                "Couldn't play a full version of that. Try another SoundCloud search or URL."
             )
         except discord.HTTPException:
             logger.debug("Failed to notify channel of track exception", exc_info=True)
@@ -315,10 +304,12 @@ class Music(commands.Cog):
                 )
                 return
 
-            candidates = rank_playable_tracks(tracks)[:MAX_PLAY_CANDIDATES]
+            # Skip Go+ previews; only fully streamable uploads (try several if one 404s).
+            candidates = full_stream_tracks(tracks)[:MAX_PLAY_CANDIDATES]
             if not candidates:
                 await ctx.send(
-                    "Couldn't find that on SoundCloud. Try a different search or paste a track URL."
+                    "Couldn't find a full streamable version on SoundCloud "
+                    "(that result is preview-only). Try another search or URL."
                 )
                 return
 
@@ -338,7 +329,6 @@ class Music(commands.Cog):
                         requester,
                         prefix=f"Queued **#{position}:** ",
                     )
-                    + _preview_note(track)
                 )
                 return
 
@@ -346,7 +336,6 @@ class Music(commands.Cog):
             await player.play(track)
             await ctx.send(
                 self._track_line(track, requester, prefix="▶️ **Now playing:** ")
-                + _preview_note(track)
             )
 
     @commands.hybrid_command(brief="Skip the current track")

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -19,6 +19,7 @@ from utils.interactions import acknowledge
 logger = logging.getLogger(__name__)
 
 MAX_QUEUE_SIZE = 50
+MAX_PLAY_CANDIDATES = 5
 
 SOUNDCLOUD_HOSTS = frozenset({
     "soundcloud.com",
@@ -95,16 +96,30 @@ def is_preview_track(track: wavelink.Playable) -> bool:
     return False
 
 
-def pick_playable_track(tracks) -> Optional[wavelink.Playable]:
-    """Prefer a full stream over a SoundCloud preview clip."""
+def rank_playable_tracks(tracks) -> list[wavelink.Playable]:
+    """Order candidates: full streams first, then previews (search order preserved)."""
     if isinstance(tracks, wavelink.Playlist):
         candidates = list(tracks.tracks)
     else:
         candidates = list(tracks)
-    for track in candidates:
-        if not is_preview_track(track):
-            return track
-    return candidates[0] if candidates else None
+    full = [t for t in candidates if not is_preview_track(t)]
+    previews = [t for t in candidates if is_preview_track(t)]
+    return full + previews
+
+
+def pick_playable_track(tracks) -> Optional[wavelink.Playable]:
+    """Prefer a full stream over a SoundCloud preview clip."""
+    ranked = rank_playable_tracks(tracks)
+    return ranked[0] if ranked else None
+
+
+def _preview_note(track: wavelink.Playable) -> str:
+    if not is_preview_track(track):
+        return ""
+    return (
+        "\n⚠️ SoundCloud only allows a short preview of this track "
+        "(full stream needs Go+)."
+    )
 
 
 def _track_url(track: wavelink.Playable) -> str:
@@ -156,12 +171,47 @@ class Music(commands.Cog):
     async def on_wavelink_track_exception(
         self, payload: wavelink.TrackExceptionEventPayload
     ) -> None:
-        """Surface stream failures instead of silent 'playing'."""
+        """Try the next search candidate; only complain if nothing else will play."""
         exc = payload.exception or {}
         message = str(exc.get("message") or exc.get("cause") or exc)
         logger.error("Track exception for %r: %s", getattr(payload.track, "title", None), message)
         player = payload.player
-        text_channel = getattr(player, "music_text_channel", None) if player is not None else None
+        if player is None:
+            return
+
+        text_channel = getattr(player, "music_text_channel", None)
+        requester = getattr(player, "music_requester", None) or "someone"
+        fallbacks: list[wavelink.Playable] = list(
+            getattr(player, "music_fallbacks", None) or []
+        )
+
+        while fallbacks:
+            next_track = fallbacks.pop(0)
+            player.music_fallbacks = fallbacks  # type: ignore[attr-defined]
+            try:
+                await player.play(next_track)
+            except Exception:
+                logger.exception(
+                    "Failed starting fallback track %r",
+                    getattr(next_track, "title", None),
+                )
+                continue
+            if text_channel is not None:
+                note = _preview_note(next_track)
+                try:
+                    await text_channel.send(
+                        self._track_line(
+                            next_track,
+                            requester,
+                            prefix="▶️ **Playing instead:** ",
+                        )
+                        + note
+                    )
+                except discord.HTTPException:
+                    logger.debug("Failed to notify channel of fallback play", exc_info=True)
+            return
+
+        player.music_fallbacks = []  # type: ignore[attr-defined]
         if text_channel is None:
             return
         try:
@@ -179,6 +229,18 @@ class Music(commands.Cog):
             f"{prefix}**{title}** ({duration})\n"
             f"<{_track_url(track)}> — {requester}"
         )
+
+    def _arm_play_candidates(
+        self,
+        player: wavelink.Player,
+        candidates: list[wavelink.Playable],
+        requester: str,
+    ) -> wavelink.Playable:
+        """Play/queue the best candidate and keep the rest for exception fallback."""
+        track = candidates[0]
+        player.music_fallbacks = candidates[1:]  # type: ignore[attr-defined]
+        player.music_requester = requester  # type: ignore[attr-defined]
+        return track
 
     async def _ensure_player(self, ctx: commands.Context) -> wavelink.Player:
         if ctx.guild is None:
@@ -253,26 +315,21 @@ class Music(commands.Cog):
                 )
                 return
 
-            track = pick_playable_track(tracks)
-            if track is None:
+            candidates = rank_playable_tracks(tracks)[:MAX_PLAY_CANDIDATES]
+            if not candidates:
                 await ctx.send(
                     "Couldn't find that on SoundCloud. Try a different search or paste a track URL."
                 )
                 return
 
             requester = ctx.author.display_name
-            preview_note = ""
-            if is_preview_track(track):
-                # Direct URL (or all search hits) may still be preview-only.
-                preview_note = (
-                    "\n⚠️ SoundCloud only allows a short preview of this track "
-                    "(full stream needs Go+). Try another upload or search."
-                )
 
             if player.current is not None or len(player.queue) > 0:
                 if len(player.queue) >= MAX_QUEUE_SIZE:
                     await ctx.send(f"Queue is full ({MAX_QUEUE_SIZE} tracks).")
                     return
+                # Queue only the best hit — fallbacks are armed when a track starts.
+                track = candidates[0]
                 await player.queue.put_wait(track)
                 position = len(player.queue)
                 await ctx.send(
@@ -281,14 +338,15 @@ class Music(commands.Cog):
                         requester,
                         prefix=f"Queued **#{position}:** ",
                     )
-                    + preview_note
+                    + _preview_note(track)
                 )
                 return
 
+            track = self._arm_play_candidates(player, candidates, requester)
             await player.play(track)
             await ctx.send(
                 self._track_line(track, requester, prefix="▶️ **Now playing:** ")
-                + preview_note
+                + _preview_note(track)
             )
 
     @commands.hybrid_command(brief="Skip the current track")

--- a/deploy/lavalink/application.yml
+++ b/deploy/lavalink/application.yml
@@ -23,8 +23,8 @@ lavalink:
     useSeekGhosting: true
     playerUpdateInterval: 5
     soundcloudSearchEnabled: true
-    # Keep Go+ previews in search so we can fall back when a "full" stream 404s.
-    soundcloudFilterOutPreviewTracks: false
+    # Drop Go+ ~30s previews; /play only uses fully streamable uploads.
+    soundcloudFilterOutPreviewTracks: true
     gc-warnings: true
 
 metrics:

--- a/deploy/lavalink/application.yml
+++ b/deploy/lavalink/application.yml
@@ -23,8 +23,8 @@ lavalink:
     useSeekGhosting: true
     playerUpdateInterval: 5
     soundcloudSearchEnabled: true
-    # Skip ~30s Go+ preview streams so /play doesn't cut songs short.
-    soundcloudFilterOutPreviewTracks: true
+    # Keep Go+ previews in search so we can fall back when a "full" stream 404s.
+    soundcloudFilterOutPreviewTracks: false
     gc-warnings: true
 
 metrics:

--- a/docs/self_knowledge/music.md
+++ b/docs/self_knowledge/music.md
@@ -29,9 +29,9 @@ Also works with the `_play` prefix.
 ## Tips for members
 
 - You must be in a voice channel before `/play`.
-- Search uses SoundCloud's top match — if it's wrong, paste the exact URL instead.
-- Some official uploads are **preview-only** on SoundCloud (~30 seconds). The bot
-  skips those in search when a full stream exists; if a pasted URL is preview-only,
-  it will warn you. Try a different upload of the same song.
+- Search uses SoundCloud's top matches — full streams are tried first; if one
+  fails, the bot automatically tries another result (including short previews).
+- If a track is preview-only (~30 seconds), the bot will say so. Try another
+  upload of the same song for a full play.
 - `/voice` is different: that one answers a prompt as an MP3 file in chat, not
   voice-channel music.

--- a/docs/self_knowledge/music.md
+++ b/docs/self_knowledge/music.md
@@ -29,9 +29,9 @@ Also works with the `_play` prefix.
 ## Tips for members
 
 - You must be in a voice channel before `/play`.
-- Search uses SoundCloud's top matches — full streams are tried first; if one
-  fails, the bot automatically tries another result (including short previews).
-- If a track is preview-only (~30 seconds), the bot will say so. Try another
-  upload of the same song for a full play.
+- Only **fully streamable** SoundCloud uploads are used — Go+ ~30s previews are
+  skipped. If the first result fails, the bot tries another full upload.
+- If every hit is preview-only, you'll get a message to try a different search
+  or URL.
 - `/voice` is different: that one answers a prompt as an MP3 file in chat, not
   voice-channel music.

--- a/tests/test_music_commands.py
+++ b/tests/test_music_commands.py
@@ -12,6 +12,7 @@ from cogs.music import (
     is_preview_track,
     is_soundcloud_url,
     pick_playable_track,
+    rank_playable_tracks,
     safe_title,
     to_search_query,
 )
@@ -76,16 +77,20 @@ def test_is_preview_track(report):
     assert is_preview_track(full) is False
 
 
-def test_pick_playable_track_skips_preview(report):
+def test_rank_playable_tracks_full_then_preview(report):
     preview = MagicMock()
     preview.identifier = "https://api-v2.soundcloud.com/media/x/preview/hls"
     preview.uri = "https://soundcloud.com/a/preview-song"
-    full = MagicMock()
-    full.identifier = "https://api-v2.soundcloud.com/media/x/stream/hls"
-    full.uri = "https://soundcloud.com/a/full-song"
-    chosen = pick_playable_track([preview, full])
-    report.record("picks full over preview", full, chosen, section=SECTION_COMMANDS)
-    assert chosen is full
+    full_a = MagicMock()
+    full_a.identifier = "https://api-v2.soundcloud.com/media/a/stream/hls"
+    full_a.uri = "https://soundcloud.com/a/full-a"
+    full_b = MagicMock()
+    full_b.identifier = "https://api-v2.soundcloud.com/media/b/stream/hls"
+    full_b.uri = "https://soundcloud.com/a/full-b"
+    ranked = rank_playable_tracks([preview, full_a, full_b])
+    report.record("rank order", [full_a, full_b, preview], ranked, section=SECTION_COMMANDS)
+    assert ranked == [full_a, full_b, preview]
+    assert pick_playable_track([preview, full_a, full_b]) is full_a
 
 
 def test_lavalink_user_message_offline(report):
@@ -188,7 +193,7 @@ async def test_play_starts_when_idle(report, mock_bot, mock_ctx):
     report.record("url wrapped to hide embed", True, True, section=SECTION_COMMANDS)
 
 
-async def test_play_skips_preview_for_full_stream(report, mock_bot, mock_ctx):
+async def test_play_prefers_full_and_keeps_preview_fallback(report, mock_bot, mock_ctx):
     mock_ctx.guild = MagicMock()
     mock_ctx.guild.id = 4
     mock_ctx.guild.me = None
@@ -225,8 +230,9 @@ async def test_play_skips_preview_for_full_stream(report, mock_bot, mock_ctx):
             await cog.play.callback(cog, mock_ctx, query="tubthumping")
 
     player.play.assert_awaited_once_with(full)
+    assert player.music_fallbacks == [preview]
     actual = mock_ctx.send.call_args.args[0]
-    report.record("skipped preview hit", True, "Fan Upload Full" in actual, section=SECTION_COMMANDS)
+    report.record("preferred full stream", True, "Fan Upload Full" in actual, section=SECTION_COMMANDS)
     assert "Fan Upload Full" in actual
     assert "preview" not in actual.lower()
 
@@ -263,6 +269,37 @@ async def test_play_warns_when_only_preview(report, mock_bot, mock_ctx):
     actual = mock_ctx.send.call_args.args[0]
     report.record("preview warning", True, "preview" in actual.lower(), section=SECTION_COMMANDS)
     assert "preview" in actual.lower()
+
+
+async def test_track_exception_plays_fallback(report, mock_bot):
+    player = MagicMock(spec=wavelink.Player)
+    player.play = AsyncMock()
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    player.music_text_channel = channel
+    player.music_requester = "Alex"
+    preview = MagicMock()
+    preview.title = "Preview Hit"
+    preview.length = 30000
+    preview.uri = "https://soundcloud.com/x/preview"
+    preview.identifier = "https://api-v2.soundcloud.com/media/x/preview/hls"
+    player.music_fallbacks = [preview]
+
+    failed = MagicMock()
+    failed.title = "Broken Full"
+    payload = MagicMock()
+    payload.exception = {"message": "Invalid status code for soundcloud stream: 404"}
+    payload.track = failed
+    payload.player = player
+
+    cog = Music(mock_bot)
+    await cog.on_wavelink_track_exception(payload)
+
+    player.play.assert_awaited_once_with(preview)
+    sent = channel.send.await_args.args[0]
+    report.record("fallback message", True, "Playing instead" in sent, section=SECTION_COMMANDS)
+    assert "Playing instead" in sent
+    assert "Preview Hit" in sent
 
 
 async def test_queue_empty_message(report, mock_bot, mock_ctx):

--- a/tests/test_music_commands.py
+++ b/tests/test_music_commands.py
@@ -9,10 +9,10 @@ from cogs.music import (
     Music,
     _lavalink_user_message,
     format_duration,
+    full_stream_tracks,
     is_preview_track,
     is_soundcloud_url,
     pick_playable_track,
-    rank_playable_tracks,
     safe_title,
     to_search_query,
 )
@@ -77,7 +77,7 @@ def test_is_preview_track(report):
     assert is_preview_track(full) is False
 
 
-def test_rank_playable_tracks_full_then_preview(report):
+def test_full_stream_tracks_excludes_previews(report):
     preview = MagicMock()
     preview.identifier = "https://api-v2.soundcloud.com/media/x/preview/hls"
     preview.uri = "https://soundcloud.com/a/preview-song"
@@ -87,10 +87,11 @@ def test_rank_playable_tracks_full_then_preview(report):
     full_b = MagicMock()
     full_b.identifier = "https://api-v2.soundcloud.com/media/b/stream/hls"
     full_b.uri = "https://soundcloud.com/a/full-b"
-    ranked = rank_playable_tracks([preview, full_a, full_b])
-    report.record("rank order", [full_a, full_b, preview], ranked, section=SECTION_COMMANDS)
-    assert ranked == [full_a, full_b, preview]
+    full = full_stream_tracks([preview, full_a, full_b])
+    report.record("full only", [full_a, full_b], full, section=SECTION_COMMANDS)
+    assert full == [full_a, full_b]
     assert pick_playable_track([preview, full_a, full_b]) is full_a
+    assert pick_playable_track([preview]) is None
 
 
 def test_lavalink_user_message_offline(report):
@@ -193,7 +194,7 @@ async def test_play_starts_when_idle(report, mock_bot, mock_ctx):
     report.record("url wrapped to hide embed", True, True, section=SECTION_COMMANDS)
 
 
-async def test_play_prefers_full_and_keeps_preview_fallback(report, mock_bot, mock_ctx):
+async def test_play_skips_preview_and_keeps_full_fallbacks(report, mock_bot, mock_ctx):
     mock_ctx.guild = MagicMock()
     mock_ctx.guild.id = 4
     mock_ctx.guild.me = None
@@ -215,29 +216,34 @@ async def test_play_prefers_full_and_keeps_preview_fallback(report, mock_bot, mo
     preview.length = 180000
     preview.uri = "https://soundcloud.com/label/official"
     preview.identifier = "https://api-v2.soundcloud.com/media/x/preview/hls"
-    full = MagicMock()
-    full.title = "Fan Upload Full"
-    full.length = 180000
-    full.uri = "https://soundcloud.com/fan/full"
-    full.identifier = "https://api-v2.soundcloud.com/media/y/stream/hls"
+    full_a = MagicMock()
+    full_a.title = "Fan Upload A"
+    full_a.length = 180000
+    full_a.uri = "https://soundcloud.com/fan/a"
+    full_a.identifier = "https://api-v2.soundcloud.com/media/a/stream/hls"
+    full_b = MagicMock()
+    full_b.title = "Fan Upload B"
+    full_b.length = 180000
+    full_b.uri = "https://soundcloud.com/fan/b"
+    full_b.identifier = "https://api-v2.soundcloud.com/media/b/stream/hls"
 
     cog = Music(mock_bot)
     with patch.object(cog, "_ensure_player", AsyncMock(return_value=player)):
         with patch(
             "cogs.music.wavelink.Playable.search",
-            AsyncMock(return_value=[preview, full]),
+            AsyncMock(return_value=[preview, full_a, full_b]),
         ):
             await cog.play.callback(cog, mock_ctx, query="tubthumping")
 
-    player.play.assert_awaited_once_with(full)
-    assert player.music_fallbacks == [preview]
+    player.play.assert_awaited_once_with(full_a)
+    assert player.music_fallbacks == [full_b]
     actual = mock_ctx.send.call_args.args[0]
-    report.record("preferred full stream", True, "Fan Upload Full" in actual, section=SECTION_COMMANDS)
-    assert "Fan Upload Full" in actual
+    report.record("preferred full stream", True, "Fan Upload A" in actual, section=SECTION_COMMANDS)
+    assert "Fan Upload A" in actual
     assert "preview" not in actual.lower()
 
 
-async def test_play_warns_when_only_preview(report, mock_bot, mock_ctx):
+async def test_play_rejects_preview_only_results(report, mock_bot, mock_ctx):
     mock_ctx.guild = MagicMock()
     mock_ctx.guild.id = 5
     mock_ctx.guild.me = None
@@ -265,13 +271,13 @@ async def test_play_warns_when_only_preview(report, mock_bot, mock_ctx):
         with patch("cogs.music.wavelink.Playable.search", AsyncMock(return_value=[preview])):
             await cog.play.callback(cog, mock_ctx, query="safety dance")
 
-    player.play.assert_awaited_once_with(preview)
+    player.play.assert_not_called()
     actual = mock_ctx.send.call_args.args[0]
-    report.record("preview warning", True, "preview" in actual.lower(), section=SECTION_COMMANDS)
-    assert "preview" in actual.lower()
+    report.record("preview-only rejected", True, "preview-only" in actual.lower(), section=SECTION_COMMANDS)
+    assert "preview-only" in actual.lower()
 
 
-async def test_track_exception_plays_fallback(report, mock_bot):
+async def test_track_exception_plays_next_full_stream(report, mock_bot):
     player = MagicMock(spec=wavelink.Player)
     player.play = AsyncMock()
     channel = MagicMock()
@@ -280,10 +286,14 @@ async def test_track_exception_plays_fallback(report, mock_bot):
     player.music_requester = "Alex"
     preview = MagicMock()
     preview.title = "Preview Hit"
-    preview.length = 30000
-    preview.uri = "https://soundcloud.com/x/preview"
     preview.identifier = "https://api-v2.soundcloud.com/media/x/preview/hls"
-    player.music_fallbacks = [preview]
+    full_b = MagicMock()
+    full_b.title = "Full Backup"
+    full_b.length = 180000
+    full_b.uri = "https://soundcloud.com/fan/b"
+    full_b.identifier = "https://api-v2.soundcloud.com/media/b/stream/hls"
+    # Preview must be skipped; next full stream should play.
+    player.music_fallbacks = [preview, full_b]
 
     failed = MagicMock()
     failed.title = "Broken Full"
@@ -295,11 +305,11 @@ async def test_track_exception_plays_fallback(report, mock_bot):
     cog = Music(mock_bot)
     await cog.on_wavelink_track_exception(payload)
 
-    player.play.assert_awaited_once_with(preview)
+    player.play.assert_awaited_once_with(full_b)
     sent = channel.send.await_args.args[0]
     report.record("fallback message", True, "Playing instead" in sent, section=SECTION_COMMANDS)
     assert "Playing instead" in sent
-    assert "Preview Hit" in sent
+    assert "Full Backup" in sent
 
 
 async def test_queue_empty_message(report, mock_bot, mock_ctx):


### PR DESCRIPTION
## Summary
- Skip Go+ ~30s previews entirely (Lavalink filter + bot-side)
- Prefer fully streamable search hits and auto-try the next full upload when a stream 404s
- If every result is preview-only, say so instead of playing a clip

## Test plan
- [ ] `/play` on a song with broken first hit falls back to another **full** upload (no preview)
- [ ] Preview-only results are rejected with a clear message
- [ ] Successful plays show no preview warning
- [ ] CI music tests pass
