### PR TITLE
Simplify music and /voice response formatting

### DIFF
--- a/cogs/ai.py
+++ b/cogs/ai.py
@@ -65,19 +65,8 @@ async def _ensure_message_row(ctx, content: str = "") -> None:
     await loop.run_in_executor(None, db_ops.update_messages, message_data)
 
 
-def _format_prompt_context(author, prompt: str) -> str:
-    """Blockquote the prompt so slash /voice invocations are visible in-channel."""
-    attribution = f"\n— {author.mention}"
-    max_body = 2000 - len(attribution)
-    body = (prompt or "").strip() or "…"
-    if len(body) > max_body - 2:
-        body = body[: max_body - 5] + "..."
-    quoted = "\n".join(f"> {line}" if line else ">" for line in body.splitlines())
-    return f"{quoted}{attribution}"
-
-
 def _format_slash_ask_message(author, prompt: str, response: str) -> str:
-    """Format slash /ask as '@user: prompt\\n\\nresponse' (Discord 2000-char limit)."""
+    """Format slash /ask and /voice as '@user: prompt\\n\\nresponse' (Discord 2000-char limit)."""
     header = f"{author.mention}: "
     sep = "\n\n"
     prompt_body = (prompt or "").strip() or "…"
@@ -94,33 +83,12 @@ def _format_slash_ask_message(author, prompt: str, response: str) -> str:
     return f"{header}{prompt_body}{sep}{answer}"
 
 
-async def _send_slash_prompt_context(ctx, prompt: str):
-    """Post a visible prompt quote for slash /voice; no-op for prefix."""
-    if ctx.interaction is None:
-        return None
-    return await ctx.send(_format_prompt_context(ctx.author, prompt))
-
-
-async def _send_answer(ctx, context_msg, content=None, **kwargs):
-    """Reply to the slash /voice prompt quote when present; otherwise send normally."""
-    if context_msg is not None:
-        if content is not None:
-            await context_msg.reply(content, mention_author=False, **kwargs)
-        else:
-            await context_msg.reply(mention_author=False, **kwargs)
-    else:
-        if content is not None:
-            await ctx.send(content, **kwargs)
-        else:
-            await ctx.send(**kwargs)
-
-
-async def _send_ask_answer(ctx, prompt: str, content: str):
-    """Send /ask answer; slash includes '@user: prompt' in one message."""
+async def _send_ask_answer(ctx, prompt: str, content: str, **kwargs):
+    """Send /ask or /voice answer; slash includes '@user: prompt' in one message."""
     if ctx.interaction is not None:
-        await ctx.send(_format_slash_ask_message(ctx.author, prompt, content))
+        await ctx.send(_format_slash_ask_message(ctx.author, prompt, content), **kwargs)
     else:
-        await ctx.send(content)
+        await ctx.send(content, **kwargs)
 
 
 class AI(commands.Cog):
@@ -335,7 +303,6 @@ class AI(commands.Cog):
             return
 
         async with acknowledge(ctx):
-            context_msg = await _send_slash_prompt_context(ctx, prompt)
             try:
                 if self._session_turns >= MAX_GROK_SESSION_TURNS:
                     self._reset_session()
@@ -354,9 +321,9 @@ class AI(commands.Cog):
                     self._session_turns += 1
 
                 if not response_text:
-                    await _send_answer(
+                    await _send_ask_answer(
                         ctx,
-                        context_msg,
+                        prompt,
                         "Sorry, I couldn't generate a spoken response. Please try again.",
                     )
                     return
@@ -380,20 +347,25 @@ class AI(commands.Cog):
                     filename="voice.mp3"
                 )
 
-                await _send_answer(ctx, context_msg, file=audio_file)
+                # Slash: one message like /ask ('@user: prompt\\n\\nanswer' + audio).
+                # Prefix: audio only (prompt is already visible in the invoking message).
+                if ctx.interaction is not None:
+                    await _send_ask_answer(ctx, prompt, response_text, file=audio_file)
+                else:
+                    await ctx.send(file=audio_file)
 
             except requests.exceptions.RequestException:
                 logger.exception("/voice TTS request failed for user %s", ctx.author.id)
-                await _send_answer(
+                await _send_ask_answer(
                     ctx,
-                    context_msg,
+                    prompt,
                     "Something broke generating speech. Check the bot logs and try again.",
                 )
             except Exception:
                 logger.exception("/voice failed for user %s", ctx.author.id)
-                await _send_answer(
+                await _send_ask_answer(
                     ctx,
-                    context_msg,
+                    prompt,
                     "Something broke on my end, dude. Check the bot logs and try again.",
                 )
 

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -221,12 +221,11 @@ class Music(commands.Cog):
             return
 
         track = payload.track
-        requester = getattr(player, "music_requester", None) or "someone"
         player.music_announce_fallback = False  # type: ignore[attr-defined]
         # Always "Now playing" — users shouldn't see the failed candidates we walked.
         await self._send_music_message(
             player,
-            self._track_line(track, requester, prefix="▶️ **Now playing:** "),
+            self._track_line(track, prefix="▶️ **Now playing:** "),
         )
 
     @commands.Cog.listener()
@@ -270,26 +269,21 @@ class Music(commands.Cog):
             "Couldn't play a full version of that. Try another SoundCloud search or URL.",
         )
 
-    def _track_line(self, track: wavelink.Playable, requester: str, *, prefix: str = "") -> str:
+    def _track_line(self, track: wavelink.Playable, *, prefix: str = "") -> str:
         title = safe_title(getattr(track, "title", None) or "Unknown title")
         duration = format_duration(_track_duration_seconds(track))
         # Angle brackets keep the link clickable but suppress Discord's rich embed.
-        return (
-            f"{prefix}**{title}** ({duration})\n"
-            f"<{_track_url(track)}> — {requester}"
-        )
+        return f"{prefix}**{title}** ({duration})\n<{_track_url(track)}>"
 
     def _arm_play_candidates(
         self,
         player: wavelink.Player,
         candidates: list[wavelink.Playable],
-        requester: str,
         ctx: commands.Context,
     ) -> wavelink.Playable:
         """Play the best candidate; keep the rest for quiet exception fallback."""
         track = candidates[0]
         player.music_fallbacks = candidates[1:]  # type: ignore[attr-defined]
-        player.music_requester = requester  # type: ignore[attr-defined]
         player.music_pending_ctx = ctx  # type: ignore[attr-defined]
         player.music_announce_fallback = False  # type: ignore[attr-defined]
         player.music_status_message = None  # type: ignore[attr-defined]
@@ -377,8 +371,6 @@ class Music(commands.Cog):
                 )
                 return
 
-            requester = ctx.author.display_name
-
             if player.current is not None or len(player.queue) > 0:
                 if len(player.queue) >= MAX_QUEUE_SIZE:
                     await ctx.send(f"Queue is full ({MAX_QUEUE_SIZE} tracks).")
@@ -388,15 +380,11 @@ class Music(commands.Cog):
                 await player.queue.put_wait(track)
                 position = len(player.queue)
                 await ctx.send(
-                    self._track_line(
-                        track,
-                        requester,
-                        prefix=f"Queued **#{position}:** ",
-                    )
+                    self._track_line(track, prefix=f"Queued **#{position}:** ")
                 )
                 return
 
-            track = self._arm_play_candidates(player, candidates, requester, ctx)
+            track = self._arm_play_candidates(player, candidates, ctx)
             try:
                 await player.play(track)
             except Exception as exc:
@@ -453,7 +441,7 @@ class Music(commands.Cog):
         lines: list[str] = []
         if player.current is not None:
             lines.append(
-                self._track_line(player.current, "now", prefix="▶️ **Now playing:** ")
+                self._track_line(player.current, prefix="▶️ **Now playing:** ")
             )
         for index, track in enumerate(list(player.queue)[:20], start=1):
             title = safe_title(getattr(track, "title", None) or "Unknown title")
@@ -473,7 +461,7 @@ class Music(commands.Cog):
         if not isinstance(player, wavelink.Player) or player.current is None:
             await ctx.send("Nothing is playing.")
             return
-        await ctx.send(self._track_line(player.current, "now", prefix="▶️ **Now playing:** "))
+        await ctx.send(self._track_line(player.current, prefix="▶️ **Now playing:** "))
 
     @commands.hybrid_command(brief="Pause playback")
     async def pause(self, ctx: commands.Context):

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -83,16 +83,6 @@ async def test_ask_prefix_skips_message_insert(report, mock_db_ops, ai_cog, mock
     report.record("prefix message insert", "skipped", "skipped", section=SECTION_COMMANDS)
 
 
-def test_format_prompt_context_quotes_and_attributes(report, mock_author):
-    from cogs.ai import _format_prompt_context
-
-    text = _format_prompt_context(mock_author, "line one\nline two")
-    report.record("format starts with quote", True, text.startswith("> line one"), section=SECTION_COMMANDS)
-    assert "> line one" in text
-    assert "> line two" in text
-    assert mock_author.mention in text
-
-
 def test_format_slash_ask_message(report, mock_author):
     from cogs.ai import _format_slash_ask_message
 
@@ -265,6 +255,35 @@ async def test_voice_success(mock_getenv, mock_post, report, ai_cog, mock_ctx):
     mock_post.assert_called_once()
     mock_ctx.send.assert_awaited_once()
     assert audio_file.filename == "voice.mp3"
+    # Prefix: audio only (no quoted prompt / reply chain).
+    assert not mock_ctx.send.call_args.args
+
+
+@patch("cogs.ai.requests.post")
+@patch("cogs.ai.os.getenv", return_value="test-key")
+async def test_voice_slash_single_message_with_prompt(
+    mock_getenv, mock_post, report, mock_db_ops, ai_cog, mock_ctx
+):
+    from datetime import datetime, timezone
+
+    mock_ctx.interaction = MagicMock()
+    mock_ctx.message.created_at = datetime(2024, 6, 11, tzinfo=timezone.utc)
+    mock_ctx.send = AsyncMock()
+    ai_cog.grok.send_message.return_value = ("tts-id", "spoken text")
+    mock_response = MagicMock()
+    mock_response.content = b"fake-mp3"
+    mock_response.raise_for_status = MagicMock()
+    mock_post.return_value = mock_response
+
+    await ai_cog.voice.callback(ai_cog, mock_ctx, prompt="say hello")
+
+    expected = f"{mock_ctx.author.mention}: say hello\n\nspoken text"
+    actual = mock_ctx.send.call_args.args[0]
+    audio_file = mock_ctx.send.call_args.kwargs["file"]
+    report.record("slash voice message", expected, actual, section=SECTION_COMMANDS)
+    report.record("single send", 1, mock_ctx.send.await_count, section=SECTION_COMMANDS)
+    mock_ctx.send.assert_awaited_once_with(expected, file=audio_file)
+    assert audio_file.filename == "voice.mp3"
 
 
 @patch("cogs.ai.os.getenv", return_value=None)
@@ -292,3 +311,26 @@ async def test_voice_tts_failure_hides_exception(mock_getenv, mock_post, report,
     report.record("error message", expected, actual, section=SECTION_COMMANDS)
     mock_ctx.send.assert_awaited_once_with(expected)
     assert "connection reset" not in actual
+
+
+@patch("cogs.ai.requests.post")
+@patch("cogs.ai.os.getenv", return_value="test-key")
+async def test_voice_slash_error_single_message(mock_getenv, mock_post, report, mock_db_ops, ai_cog, mock_ctx):
+    import requests
+    from datetime import datetime, timezone
+
+    mock_ctx.interaction = MagicMock()
+    mock_ctx.message.created_at = datetime(2024, 6, 11, tzinfo=timezone.utc)
+    mock_ctx.send = AsyncMock()
+    ai_cog.grok.send_message.return_value = ("tts-id", "spoken text")
+    mock_post.side_effect = requests.exceptions.RequestException("connection reset")
+
+    await ai_cog.voice.callback(ai_cog, mock_ctx, prompt="say hello")
+
+    expected = (
+        f"{mock_ctx.author.mention}: say hello\n\n"
+        "Something broke generating speech. Check the bot logs and try again."
+    )
+    actual = mock_ctx.send.call_args.args[0]
+    report.record("slash voice error", expected, actual, section=SECTION_COMMANDS)
+    mock_ctx.send.assert_awaited_once_with(expected)

--- a/tests/test_music_commands.py
+++ b/tests/test_music_commands.py
@@ -156,6 +156,9 @@ async def test_play_queues_when_busy(report, mock_bot, mock_ctx):
     actual = mock_ctx.send.call_args.args[0]
     report.record("queued while busy", True, "Queued" in actual, section=SECTION_COMMANDS)
     assert "Queued" in actual
+    assert " — " not in actual
+    assert "Alex" not in actual
+    report.record("queued without requester", True, True, section=SECTION_COMMANDS)
 
 
 async def test_play_starts_when_idle(report, mock_bot, mock_ctx):
@@ -200,7 +203,10 @@ async def test_play_starts_when_idle(report, mock_bot, mock_ctx):
     report.record("now playing", True, "Now playing" in actual, section=SECTION_COMMANDS)
     assert "Now playing" in actual
     assert "<https://soundcloud.com/artist/lofi-beat>" in actual
+    assert " — " not in actual
+    assert "Alex" not in actual
     report.record("url wrapped to hide embed", True, True, section=SECTION_COMMANDS)
+    report.record("no requester name", True, True, section=SECTION_COMMANDS)
 
 
 async def test_play_skips_preview_and_keeps_full_fallbacks(report, mock_bot, mock_ctx):
@@ -300,7 +306,6 @@ async def test_track_exception_plays_next_full_stream(report, mock_bot):
     channel = MagicMock()
     channel.send = AsyncMock()
     player.music_text_channel = channel
-    player.music_requester = "Alex"
     player.music_pending_ctx = None
     player.music_status_message = None
     player.music_announce_fallback = False
@@ -340,6 +345,8 @@ async def test_track_exception_plays_next_full_stream(report, mock_bot):
     assert "Now playing" in sent
     assert "Playing instead" not in sent
     assert "Full Backup" in sent
+    assert " — " not in sent
+    report.record("no requester suffix", True, True, section=SECTION_COMMANDS)
 
 
 async def test_track_exception_hides_failed_announce(report, mock_bot):
@@ -348,7 +355,6 @@ async def test_track_exception_hides_failed_announce(report, mock_bot):
     channel = MagicMock()
     channel.send = AsyncMock()
     player.music_text_channel = channel
-    player.music_requester = "Alex"
     player.music_pending_ctx = None
     failed_msg = MagicMock()
     failed_msg.delete = AsyncMock()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Music announcements (`/play`, queue, now playing) no longer append the requester’s display name — Discord already shows who invoked the command.
- Slash `/voice` now matches `/ask`: a single channel message (`@user: prompt` + answer, with the MP3 attached) instead of a quoted prompt message and a separate reply.

## Test plan
- [x] `pytest tests/test_music_commands.py tests/test_ai_commands.py` (39 passed)
- [ ] Manually: `/play` a track and confirm the announce has title/duration/URL only
- [ ] Manually: slash `/voice` shows one message (no quote + reply chain) with audio attached

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff670-ffab-7a94-ad9c-d5a5781b356e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff670-ffab-7a94-ad9c-d5a5781b356e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

